### PR TITLE
Update documentation and warnings related to SaveBehavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 The **[Amazon DynamoDB][ddb] Client-side Encryption in Java** supports encryption and signing of your data when stored in Amazon DynamoDB.
 
 A typical use of this library is when you are using [DynamoDBMapper][ddbmapper], where transparent protection of all objects serialized through the mapper can be enabled via configuring an [AttributeEncryptor][attrencryptor].
+**Please note that it is critically important that you use `SaveBehavior.CLOBBER` when using AttributeEncryptor.**
 
 For more advanced use cases where tighter control over the encryption and signing process is necessary, the low-level [DynamoDBEncryptor][ddbencryptor] can be used directly.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The **[Amazon DynamoDB][ddb] Client-side Encryption in Java** supports encryptio
 
 A typical use of this library is when you are using [DynamoDBMapper][ddbmapper], where transparent protection of all objects serialized through the mapper can be enabled via configuring an [AttributeEncryptor][attrencryptor].
 
-> Important: Use `SaveBehavior.CLOBBER` with `AttributeEncryptor`. If you do not do so you risk corrupting your signatures and encrypted data.
+**Important: Use `SaveBehavior.CLOBBER` with `AttributeEncryptor`. If you do not do so you risk corrupting your signatures and encrypted data.**
 
 For more advanced use cases where tighter control over the encryption and signing process is necessary, the low-level [DynamoDBEncryptor][ddbencryptor] can be used directly.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The **[Amazon DynamoDB][ddb] Client-side Encryption in Java** supports encryptio
 A typical use of this library is when you are using [DynamoDBMapper][ddbmapper], where transparent protection of all objects serialized through the mapper can be enabled via configuring an [AttributeEncryptor][attrencryptor].
 
 **Important: Use `SaveBehavior.CLOBBER` with `AttributeEncryptor`. If you do not do so you risk corrupting your signatures and encrypted data.**
+When CLOBBER is not specified, fields that are present in the record may not be passed down to the encryptor, which results in fields being left out of the record signature. This in turn can result in records failing to decrypt.
 
 For more advanced use cases where tighter control over the encryption and signing process is necessary, the low-level [DynamoDBEncryptor][ddbencryptor] can be used directly.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 The **[Amazon DynamoDB][ddb] Client-side Encryption in Java** supports encryption and signing of your data when stored in Amazon DynamoDB.
 
 A typical use of this library is when you are using [DynamoDBMapper][ddbmapper], where transparent protection of all objects serialized through the mapper can be enabled via configuring an [AttributeEncryptor][attrencryptor].
-**Please note that it is critically important that you use `SaveBehavior.CLOBBER` when using AttributeEncryptor.**
+
+> Important: Use `SaveBehavior.CLOBBER` with `AttributeEncryptor`. If you do not do so you risk corrupting your signatures and encrypted data.
 
 For more advanced use cases where tighter control over the encryption and signing process is necessary, the low-level [DynamoDBEncryptor][ddbencryptor] can be used directly.
 
@@ -75,7 +76,7 @@ To enable transparent encryption and signing, simply specify the necessary encry
     SecretKey cek = ...;        // Content encrypting key
     SecretKey macKey =  ...;    // Signing key
     EncryptionMaterialsProvider provider = new SymmetricStaticProvider(cek, macKey);
-    mapper = new DynamoDBMapper(client, DynamoDBMapperConfig.DEFAULT,
+    mapper = new DynamoDBMapper(client, DynamoDBMapperConfig.builder().withSaveBehavior(SaveBehavior.CLOBBER).build(),
                 new AttributeEncryptor(provider));
     Book book = new Book();
     book.setId(123);

--- a/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
+++ b/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
@@ -52,7 +52,7 @@ public class AwsKmsEncryptedObject {
     // Encryptor creation
     final DynamoDBEncryptor encryptor = DynamoDBEncryptor.getInstance(cmp);
     // Mapper Creation
-    // Please note the use of SaveBehavior.CLOBBER. Omitting this may result in data-corruption.
+    // Please note the use of SaveBehavior.CLOBBER. Omitting this can result in data-corruption.
     DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder().withSaveBehavior(SaveBehavior.CLOBBER).build();
     DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
 

--- a/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
+++ b/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
@@ -52,6 +52,7 @@ public class AwsKmsEncryptedObject {
     // Encryptor creation
     final DynamoDBEncryptor encryptor = DynamoDBEncryptor.getInstance(cmp);
     // Mapper Creation
+    // Please note the use of SaveBehavior.CLOBBER. Omitting this may result in data-corruption.
     DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder().withSaveBehavior(SaveBehavior.CLOBBER).build();
     DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
@@ -38,8 +38,8 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * Encrypts all non-key fields prior to storing them in DynamoDB.
- * <em>It is critically important that this is only used with @{link SaveBehavior#CLOBBER}. Use of
- * any other @{code SaveBehavior} may result in data-corruption.</em>
+ * <em>This must be used with @{link SaveBehavior#CLOBBER}. Use of
+ * any other @{code SaveBehavior} can result in data-corruption.</em>
  * 
  * @author Greg Rubin 
  */
@@ -66,12 +66,14 @@ public class AttributeEncryptor implements AttributeTransformer {
         final ModelClassMetadata metadata = getModelClassMetadata(parameters);
 
         final Map<String, AttributeValue> attributeValues = parameters.getAttributeValues();
+        // If this class is marked as "DoNotTouch" then we know our encryptor will not change it at all
+        // so we may as well fast-return and do nothing. This also avoids emitting errors when they would not apply.
         if (metadata.doNotTouch) {
             return attributeValues;
         }
 
         if (parameters.isPartialUpdate()) {
-            LOG.error("Use of AttributeEncryptor without SaveBehavior.CLOBBER is an error and may result in data-corruption. " +
+            LOG.error("Use of AttributeEncryptor without SaveBehavior.CLOBBER is an error and can result in data-corruption. " +
                     "This occured while trying to save " + parameters.getModelClass());
         }
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
@@ -72,6 +72,10 @@ public class AttributeEncryptor implements AttributeTransformer {
             return attributeValues;
         }
 
+        // When AttributeEncryptor is used without SaveBehavior.CLOBBER, it is trying to transform only a subset
+        // of the actual fields stored in DynamoDB. This means that the generated signature will not cover any
+        // unmodified fields. Thus, upon untransform, the signature verification will fail as it won't cover all
+        // expected fields.
         if (parameters.isPartialUpdate()) {
             LOG.error("Use of AttributeEncryptor without SaveBehavior.CLOBBER is an error and can result in data-corruption. " +
                     "This occured while trying to save " + parameters.getModelClass());

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
@@ -14,7 +14,11 @@
  */
 package com.amazonaws.services.dynamodbv2.datamodeling;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.SaveBehavior;

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/TransformerHolisticTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/TransformerHolisticTests.java
@@ -115,6 +115,9 @@ public class TransformerHolisticTests {
     private static final EncryptionMaterialsProvider symWrappedProv;
 
     private AmazonDynamoDB client;
+    // AttributeEncryptor *must* be used with SaveBehavior.CLOBBER to avoid the risk of data corruption.
+    private static final DynamoDBMapperConfig CLOBBER_CONFIG =
+            DynamoDBMapperConfig.builder().withSaveBehavior(SaveBehavior.CLOBBER).build();
     private static final BaseClass ENCRYPTED_TEST_VALUE = new BaseClass();
     private static final Mixed MIXED_TEST_VALUE = new Mixed();
     private static final SignOnly SIGNED_TEST_VALUE = new SignOnly();
@@ -292,7 +295,7 @@ public class TransformerHolisticTests {
 
     @Test
     public void simpleSaveLoad() {
-        DynamoDBMapper mapper = new DynamoDBMapper(client, DynamoDBMapperConfig.DEFAULT, new AttributeEncryptor(symProv));
+        DynamoDBMapper mapper = new DynamoDBMapper(client, CLOBBER_CONFIG, new AttributeEncryptor(symProv));
         Mixed obj = new Mixed();
         obj.setHashKey(0);
         obj.setRangeKey(15);
@@ -322,7 +325,7 @@ public class TransformerHolisticTests {
 
     @Test
     public void leadingAndTrailingZeros() {
-        DynamoDBMapper mapper = new DynamoDBMapper(client, DynamoDBMapperConfig.DEFAULT, new AttributeEncryptor(symProv));
+        DynamoDBMapper mapper = new DynamoDBMapper(client, CLOBBER_CONFIG, new AttributeEncryptor(symProv));
         Mixed obj = new Mixed();
         obj.setHashKey(0);
         obj.setRangeKey(15);
@@ -364,7 +367,7 @@ public class TransformerHolisticTests {
     
     @Test
     public void simpleSaveLoadAsym() {
-        DynamoDBMapper mapper = new DynamoDBMapper(client, DynamoDBMapperConfig.DEFAULT, new AttributeEncryptor(asymProv));
+        DynamoDBMapper mapper = new DynamoDBMapper(client, CLOBBER_CONFIG, new AttributeEncryptor(asymProv));
         
         BaseClass obj = new BaseClass();
         obj.setHashKey(0);
@@ -394,7 +397,7 @@ public class TransformerHolisticTests {
 
     @Test
     public void simpleSaveLoadHashOnly() {
-        DynamoDBMapper mapper = new DynamoDBMapper(client, DynamoDBMapperConfig.DEFAULT, new AttributeEncryptor(
+        DynamoDBMapper mapper = new DynamoDBMapper(client, CLOBBER_CONFIG, new AttributeEncryptor(
                 symProv));
         
         HashKeyOnly obj = new HashKeyOnly("");
@@ -411,7 +414,7 @@ public class TransformerHolisticTests {
 
     @Test
     public void simpleSaveLoadKeysOnly() {
-        DynamoDBMapper mapper = new DynamoDBMapper(client, DynamoDBMapperConfig.DEFAULT, new AttributeEncryptor(
+        DynamoDBMapper mapper = new DynamoDBMapper(client, CLOBBER_CONFIG, new AttributeEncryptor(
                 asymProv));
         
         KeysOnly obj = new KeysOnly();

--- a/src/test/java/com/amazonaws/services/dynamodbv2/testing/FakeParameters.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/testing/FakeParameters.java
@@ -26,13 +26,19 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 public class FakeParameters<T> {
     public static <T> AttributeTransformer.Parameters<T> getInstance(Class<T> clazz,
+                                                                     Map<String, AttributeValue> attribs, DynamoDBMapperConfig config, String tableName,
+                                                                     String hashKeyName, String rangeKeyName) {
+        return getInstance(clazz, attribs, config, tableName, hashKeyName, rangeKeyName, false);
+    }
+
+    public static <T> AttributeTransformer.Parameters<T> getInstance(Class<T> clazz,
             Map<String, AttributeValue> attribs, DynamoDBMapperConfig config, String tableName,
-            String hashKeyName, String rangeKeyName) {
+            String hashKeyName, String rangeKeyName, boolean isPartialUpdate) {
 
         // We use this relatively insane proxy setup so that modifications to the Parameters
         // interface doesn't break our tests (unless it actually impacts our code).
         FakeParameters<T> fakeParams = new FakeParameters<T>(clazz, attribs, config, tableName,
-                hashKeyName, rangeKeyName);
+                hashKeyName, rangeKeyName, isPartialUpdate);
         @SuppressWarnings("unchecked")
         AttributeTransformer.Parameters<T> proxyObject = (AttributeTransformer.Parameters<T>) Proxy
                 .newProxyInstance(AttributeTransformer.class.getClassLoader(),
@@ -65,9 +71,11 @@ public class FakeParameters<T> {
     private final String tableName;
     private final String hashKeyName;
     private final String rangeKeyName;
+    private final boolean isPartialUpdate;
 
     private FakeParameters(Class<T> clazz, Map<String, AttributeValue> attribs,
-            DynamoDBMapperConfig config, String tableName, String hashKeyName, String rangeKeyName) {
+            DynamoDBMapperConfig config, String tableName, String hashKeyName, String rangeKeyName,
+            boolean isPartialUpdate) {
         super();
         this.clazz = clazz;
         this.attrs = Collections.unmodifiableMap(attribs);
@@ -75,6 +83,7 @@ public class FakeParameters<T> {
         this.tableName = tableName;
         this.hashKeyName = hashKeyName;
         this.rangeKeyName = rangeKeyName;
+        this.isPartialUpdate = isPartialUpdate;
     }
 
     public Map<String, AttributeValue> getAttributeValues() {
@@ -99,5 +108,9 @@ public class FakeParameters<T> {
 
     public String getRangeKeyName() {
         return rangeKeyName;
+    }
+
+    public boolean isPartialUpdate() {
+        return isPartialUpdate;
     }
 }


### PR DESCRIPTION
This is in support of issue #42 

This adds basic documentation to `AttributeEncryptor` and related example code highlighting the importance of using `SaveBehavior.CLOBBER`.

All existing tests pass. Some of the existing tests did not properly set this configuration and resulted in proper warnings during the test run:

    SEVERE: Use of AttributeEncryptor without SaveBehavior.CLOBBER is an error and may result in data-corruption. This occured while trying to save class com.amazonaws.services.dynamodbv2.testing.types.Mixed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.