### PR TITLE
Force use of SaveBehavior.PUT or SaveBehavior.CLOBBER. Issue #32

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
@@ -38,8 +38,7 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * Encrypts all non-key fields prior to storing them in DynamoDB.
- * <em>This must be used with @{link SaveBehavior#PUT} or @{link SaveBehavior#CLOBBER}. Use of
- * any other @{code SaveBehavior} can result in data-corruption.</em>
+ * <em>This must be used with @{link SaveBehavior#PUT} or @{link SaveBehavior#CLOBBER}.</em>
  * 
  * @author Greg Rubin 
  */
@@ -77,7 +76,8 @@ public class AttributeEncryptor implements AttributeTransformer {
         // unmodified fields. Thus, upon untransform, the signature verification will fail as it won't cover all
         // expected fields.
         if (parameters.isPartialUpdate()) {
-            LOG.error("Use of AttributeEncryptor without SaveBehavior.PUT or SaveBehavior.CLOBBER is an error " +
+            throw new DynamoDBMappingException(
+                "Use of AttributeEncryptor without SaveBehavior.PUT or SaveBehavior.CLOBBER is an error " +
 	        "and can result in data-corruption. This occured while trying to save " +
 	        parameters.getModelClass());
         }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptorTest.java
@@ -130,6 +130,13 @@ public class AttributeEncryptorTest {
     }
 
     @Test(expected = DynamoDBMappingException.class)
+    public void rejectsPartialUpdate() {
+        Parameters<BaseClass> params = FakeParameters.getInstance(BaseClass.class, attribs, null,
+            TABLE_NAME, HASH_KEY, RANGE_KEY, true);
+        encryptor.transform(params);
+    }
+
+    @Test(expected = DynamoDBMappingException.class)
     public void fullEncryptionBadSignature() {
         Parameters<BaseClass> params = FakeParameters.getInstance(BaseClass.class, attribs, null,
                 TABLE_NAME, HASH_KEY, RANGE_KEY);


### PR DESCRIPTION
Issue #32 

This change causes the `AttributeEncryptor` to reject any unsafe use of `SaveBehavior` other than `PUT` or `CLOBBER` with a `DynamoDBMappingException`. This falls under the (as yet unreleased) minor version bump to 1.12.0 from PR #47 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
