### PR TITLE
New tests to cover more data types and optimistic locking. Also increments SDK dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
-        <version>1.11.380</version>
+        <version>1.11.434</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
@@ -31,6 +31,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Security;
 import java.security.SignatureException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -95,6 +96,34 @@ public class DynamoDBEncryptorTest {
         attribs.put("hashKey", new AttributeValue().withN("5"));
         attribs.put("rangeKey", new AttributeValue().withN("7"));
         attribs.put("version", new AttributeValue().withN("0"));
+
+        // New(er) data types
+        attribs.put("booleanTrue", new AttributeValue().withBOOL(true));
+        attribs.put("booleanFalse", new AttributeValue().withBOOL(false));
+        attribs.put("nullValue", new AttributeValue().withNULL(true));
+        Map<String, AttributeValue> tmpMap = new HashMap<>(attribs);
+        attribs.put("listValue", new AttributeValue().withL(
+                new AttributeValue().withS("I'm a string"),
+                new AttributeValue().withN("42"),
+                new AttributeValue().withS("Another string"),
+                new AttributeValue().withNS("1", "4", "7"),
+                new AttributeValue().withM(tmpMap),
+                new AttributeValue().withL(
+                        new AttributeValue().withN("123"),
+                        new AttributeValue().withNS("1", "200", "10", "15", "0"),
+                        new AttributeValue().withSS("Goodbye", "Cruel", "World", "!")
+                )));
+        tmpMap = new HashMap<>();
+        tmpMap.put("another string", new AttributeValue().withS("All around the cobbler's bench"));
+        tmpMap.put("next line", new AttributeValue().withSS("the monkey", "chased", "the weasel"));
+        tmpMap.put("more lyrics", new AttributeValue().withL(
+                new AttributeValue().withS("the monkey"),
+                new AttributeValue().withS("thought twas"),
+                new AttributeValue().withS("all in fun")
+        ));
+        tmpMap.put("weasel", new AttributeValue().withM(Collections.singletonMap("pop", new AttributeValue().withBOOL(true))));
+        attribs.put("song", new AttributeValue().withM(tmpMap));
+
 
         context = new EncryptionContext.Builder()
             .withTableName("TableName")

--- a/src/test/java/com/amazonaws/services/dynamodbv2/testing/AttrMatcher.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/testing/AttrMatcher.java
@@ -60,12 +60,39 @@ public class AttrMatcher extends BaseMatcher<Map<String, AttributeValue>> {
 
     public static boolean attrEquals(AttributeValue e, AttributeValue a) {
         if (!isEqual(e.getB(), a.getB()) ||
+                !isEqual(e.getBOOL(), a.getBOOL()) ||
+                !isSetEqual(e.getBS(), a.getBS()) ||
                 !isEqual(e.getN(), a.getN()) ||
+                !isSetEqual(e.getNS(), a.getNS()) ||
+                !isEqual(e.getNULL(), a.getNULL()) ||
                 !isEqual(e.getS(), a.getS()) ||
-                !isEqual(e.getBS(), a.getBS()) ||
-                !isEqual(e.getNS(), a.getNS()) ||
-                !isEqual(e.getSS(), a.getSS())) {
+                !isSetEqual(e.getSS(), a.getSS())) {
             return false;
+        }
+        // Recursive types need special handling
+        if (e.getM() == null ^ a.getM() == null) {
+            return false;
+        } else if (e.getM() != null) {
+            if (!e.getM().keySet().equals(a.getM().keySet())) {
+                return false;
+            }
+            for (final String key : e.getM().keySet()) {
+                if (!attrEquals(e.getM().get(key), a.getM().get(key))) {
+                    return false;
+                }
+            }
+        }
+        if (e.getL() == null ^ a.getL() == null) {
+            return false;
+        } else if (e.getL() != null) {
+            if (e.getL().size() != a.getL().size()) {
+                return false;
+            }
+            for (int x = 0; x < e.getL().size(); x++) {
+                if (!attrEquals(e.getL().get(x), a.getL().get(x))) {
+                    return false;
+                }
+            }
         }
         return true;
     }
@@ -82,7 +109,7 @@ public class AttrMatcher extends BaseMatcher<Map<String, AttributeValue>> {
         return o1.equals(o2);
     }
     
-    private static <T> boolean isEqual(Collection<T> c1, Collection<T> c2) {
+    private static <T> boolean isSetEqual(Collection<T> c1, Collection<T> c2) {
         if(c1 == null ^ c2 == null) {
             return false;
         }


### PR DESCRIPTION
*Description of changes:*

These new tests explicitly cover encryption & decryption of non-original DynamoDB data-types as well as ensure that optimistic locking works properly with `SaveBehavior.PUT`. To support `SaveBehavior.PUT` this change also updates the dependency on aws-sdk-java-bom to the current version `1.11.434`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
