### PR TITLE
Add support for running tests on OSX and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cleanup.sh
 release.sh
 target
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -83,10 +83,26 @@
     </dependency>
 
     <dependency>
-        <groupId>com.almworks.sqlite4java</groupId>
-        <artifactId>sqlite4java</artifactId>
-        <version>${sqlite4java.version}</version>
-        <scope>test</scope>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>sqlite4java</artifactId>
+      <version>${sqlite4java.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>libsqlite4java-osx</artifactId>
+      <version>${sqlite4java.version}</version>
+      <type>dylib</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>sqlite4java-win32-x64</artifactId>
+      <version>${sqlite4java.version}</version>
+      <type>dll</type>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -136,21 +152,14 @@
         <executions>
           <execution>
             <id>copy</id>
-            <phase>compile</phase>
+            <phase>test-compile</phase>
             <goals>
-              <goal>copy</goal>
+              <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.almworks.sqlite4java</groupId>
-                  <artifactId>libsqlite4java-linux-amd64</artifactId>
-                  <version>${sqlite4java.version}</version>
-                  <type>so</type>
-                  <overWrite>true</overWrite>
-                  <outputDirectory>${project.build.directory}/test-lib</outputDirectory>
-                </artifactItem>
-              </artifactItems>
+              <includeScope>test</includeScope>
+              <includeTypes>so,dll,dylib</includeTypes>
+              <outputDirectory>${project.build.directory}/test-lib</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -159,8 +168,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.22.1</version>
         <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
             <include>**/Test*.java</include>
             <include>**/*Test.java</include>


### PR DESCRIPTION
Modify the copy-dependencies plugin configuration to copy dlls, dylibs,
and .so's to the test-lib directory so that tests can be run on more platforms.
Switch the phase to test-compile, since the libs aren't a compilation
requirement.

Update the maven surefire dependency and disable the system classloader for
tests for this bug in some versions of the JDK (like on ubuntu right now):

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925

Tested on Ubuntu and OSX, not sure whether Windows works since I didn't try but it should.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
