### PR TITLE
Update README to specify JDK8 or greater, and update .travis.yml to use JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
-  - openjdk7
-  - oraclejdk7
+  - openjdk8
+  - oraclejdk8
 install: /bin/true
 script: mvn install --quiet -Dgpg.skip=true -DskipTests=true
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ For more advanced use cases where tighter control over the encryption and signin
 
 ## Getting Started
 
+### Required Prerequisites
+To use this SDK you must have:
+
+* **A Java 8 development environment**
+
+  If you do not have one, go to [Java SE Downloads](https://www.oracle.com/technetwork/java/javase/downloads/index.html) on the Oracle website, then download and install the Java SE Development Kit (JDK). Java 8 or higher is recommended.
+
+  **Note:** If you use the Oracle JDK, you must also download and install the [Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html).
+
+### Get Started
+
 Suppose you have created ([sample code][createtable]) a DynamoDB table "MyStore", and want to store some Book objects.  The security requirement involves classifying the attributes Title and Authors as sensitive information.  This is how the Book class may look like:
 
 ```java


### PR DESCRIPTION
This updates the readme to specify the JDK version used by the project to be at least JDK8. Let me know if we need JDK7 builds after all, my opinion is just based on what is inside the pom.xml and other build configurations.

Tested JDK7 using Travis - test failed, due to "[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project aws-dynamodb-encryption-java: Fatal error compiling: invalid target release: 1.8 -> [Help 1]"

Updated .travis.yml to JDK8 and tested on Travis - tests passed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
