### PR TITLE
Add support for EncryptionContext overrides to the DynamoDBEncryptor

### DIFF
--- a/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
+++ b/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
@@ -52,7 +52,8 @@ public class AwsKmsEncryptedObject {
     // Encryptor creation
     final DynamoDBEncryptor encryptor = DynamoDBEncryptor.getInstance(cmp);
     // Mapper Creation
-    // Please note the use of SaveBehavior.CLOBBER. Omitting this can result in data-corruption.
+    // Please note the use of SaveBehavior.CLOBBER (SaveBehavior.PUT works as well).
+    // Omitting this can result in data-corruption.
     DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder().withSaveBehavior(SaveBehavior.CLOBBER).build();
     DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
 

--- a/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
+++ b/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
@@ -52,9 +52,9 @@ public class AwsKmsEncryptedObject {
     // Encryptor creation
     final DynamoDBEncryptor encryptor = DynamoDBEncryptor.getInstance(cmp);
     // Mapper Creation
-    // Please note the use of SaveBehavior.CLOBBER (SaveBehavior.PUT works as well).
+    // Please note the use of SaveBehavior.PUT (SaveBehavior.CLOBBER works as well).
     // Omitting this can result in data-corruption.
-    DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder().withSaveBehavior(SaveBehavior.CLOBBER).build();
+    DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder().withSaveBehavior(SaveBehavior.PUT).build();
     DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
 
     System.out.println("Plaintext Record: " + record);

--- a/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
+++ b/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
@@ -1,0 +1,115 @@
+package com.amazonaws.examples;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.dynamodbv2.datamodeling.AttributeEncryptor;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DynamoDBEncryptor;
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers.DirectKmsMaterialProvider;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
+
+import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils.EncryptionContextOperators.overrideEncryptionContextTableNameUsingMap;
+
+public class EncryptionContextOverridesWithDynamoDBMapper {
+    public static void main(String[] args) throws GeneralSecurityException {
+        final String cmkArn = args[0];
+        final String region = args[1];
+        final String encryptionContextTableName = args[2];
+
+        encryptRecord(cmkArn, region, encryptionContextTableName);
+    }
+
+    public static void encryptRecord(final String cmkArn,
+                                     final String region,
+                                     final String newEncryptionContextTableName) {
+        // Sample object to be encrypted
+        ExampleItem record = new ExampleItem();
+        record.setPartitionAttribute("is this");
+        record.setSortAttribute(55);
+        record.setExample("my data");
+
+        // Set up our configuration and clients
+        final AmazonDynamoDB ddb = AmazonDynamoDBClientBuilder.standard().withRegion(region).build();
+        final AWSKMS kms = AWSKMSClientBuilder.standard().withRegion(region).build();
+        final DirectKmsMaterialProvider cmp = new DirectKmsMaterialProvider(kms, cmkArn);
+        // Encryptor creation
+        final DynamoDBEncryptor encryptor = DynamoDBEncryptor.getInstance(cmp);
+
+        Map<String, String> tableNameEncryptionContextOverrides = new HashMap<>();
+        tableNameEncryptionContextOverrides.put("ExampleTableForEncryptionContextOverrides", newEncryptionContextTableName);
+        tableNameEncryptionContextOverrides.put("AnotherExampleTableForEncryptionContextOverrides", "this table doesn't exist");
+
+        // Here we supply an operator to override the table name used in the encryption context
+        encryptor.setEncryptionContextOverrideOperator(
+                overrideEncryptionContextTableNameUsingMap(tableNameEncryptionContextOverrides)
+        );
+
+        // Mapper Creation
+        // Please note the use of SaveBehavior.CLOBBER (SaveBehavior.PUT works as well).
+        // Omitting this can result in data-corruption.
+        DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder()
+                .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.CLOBBER).build();
+        DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
+
+        System.out.println("Plaintext Record: " + record);
+        // Save the record to the DynamoDB table
+        mapper.save(record);
+
+        // Retrieve the encrypted record (directly without decrypting) from Dynamo so we can see it in our example
+        final Map<String, AttributeValue> itemKey = new HashMap<>();
+        itemKey.put("partition_attribute", new AttributeValue().withS("is this"));
+        itemKey.put("sort_attribute", new AttributeValue().withN("55"));
+        System.out.println("Encrypted Record: " + ddb.getItem("ExampleTableForEncryptionContextOverrides",
+                itemKey).getItem());
+
+        // Retrieve (and decrypt) it from DynamoDB
+        ExampleItem decrypted_record = mapper.load(ExampleItem.class, "is this", 55);
+        System.out.println("Decrypted Record: " + decrypted_record);
+    }
+
+    @DynamoDBTable(tableName = "ExampleTableForEncryptionContextOverrides")
+    public static final class ExampleItem {
+        private String partitionAttribute;
+        private int sortAttribute;
+        private String example;
+
+        @DynamoDBHashKey(attributeName = "partition_attribute")
+        public String getPartitionAttribute() {
+            return partitionAttribute;
+        }
+
+        public void setPartitionAttribute(String partitionAttribute) {
+            this.partitionAttribute = partitionAttribute;
+        }
+
+        @DynamoDBRangeKey(attributeName = "sort_attribute")
+        public int getSortAttribute() {
+            return sortAttribute;
+        }
+
+        public void setSortAttribute(int sortAttribute) {
+            this.sortAttribute = sortAttribute;
+        }
+
+        @DynamoDBAttribute(attributeName = "example")
+        public String getExample() {
+            return example;
+        }
+
+        public void setExample(String example) {
+            this.example = example;
+        }
+    }
+
+}

--- a/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
+++ b/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
@@ -71,10 +71,10 @@ public class EncryptionContextOverridesWithDynamoDBMapper {
         );
 
         // Mapper Creation
-        // Please note the use of SaveBehavior.CLOBBER (SaveBehavior.PUT works as well).
+        // Please note the use of SaveBehavior.PUT (SaveBehavior.CLOBBER works as well).
         // Omitting this can result in data-corruption.
         DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder()
-                .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.CLOBBER).build();
+                .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.PUT).build();
         DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
 
         System.out.println("Plaintext Record: " + record.toString());

--- a/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
+++ b/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
@@ -10,14 +10,18 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DynamoDBEncryptor;
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionContext;
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionFlags;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers.DirectKmsMaterialProvider;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
 
 import java.security.GeneralSecurityException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils.EncryptionContextOperators.overrideEncryptionContextTableNameUsingMap;
 
@@ -27,12 +31,26 @@ public class EncryptionContextOverridesWithDynamoDBMapper {
         final String region = args[1];
         final String encryptionContextTableName = args[2];
 
-        encryptRecord(cmkArn, region, encryptionContextTableName);
+        AmazonDynamoDB ddb = null;
+        AWSKMS kms = null;
+        try {
+            ddb = AmazonDynamoDBClientBuilder.standard().withRegion(region).build();
+            kms = AWSKMSClientBuilder.standard().withRegion(region).build();
+            encryptRecord(cmkArn, encryptionContextTableName, ddb, kms);
+        } finally {
+            if (ddb != null) {
+                ddb.shutdown();
+            }
+            if (kms != null) {
+                kms.shutdown();
+            }
+        }
     }
 
     public static void encryptRecord(final String cmkArn,
-                                     final String region,
-                                     final String newEncryptionContextTableName) {
+                                     final String newEncryptionContextTableName,
+                                     AmazonDynamoDB ddb,
+                                     AWSKMS kms) throws GeneralSecurityException {
         // Sample object to be encrypted
         ExampleItem record = new ExampleItem();
         record.setPartitionAttribute("is this");
@@ -40,17 +58,14 @@ public class EncryptionContextOverridesWithDynamoDBMapper {
         record.setExample("my data");
 
         // Set up our configuration and clients
-        final AmazonDynamoDB ddb = AmazonDynamoDBClientBuilder.standard().withRegion(region).build();
-        final AWSKMS kms = AWSKMSClientBuilder.standard().withRegion(region).build();
         final DirectKmsMaterialProvider cmp = new DirectKmsMaterialProvider(kms, cmkArn);
-        // Encryptor creation
         final DynamoDBEncryptor encryptor = DynamoDBEncryptor.getInstance(cmp);
 
         Map<String, String> tableNameEncryptionContextOverrides = new HashMap<>();
         tableNameEncryptionContextOverrides.put("ExampleTableForEncryptionContextOverrides", newEncryptionContextTableName);
         tableNameEncryptionContextOverrides.put("AnotherExampleTableForEncryptionContextOverrides", "this table doesn't exist");
 
-        // Here we supply an operator to override the table name used in the encryption context
+        // Supply an operator to override the table name used in the encryption context
         encryptor.setEncryptionContextOverrideOperator(
                 overrideEncryptionContextTableNameUsingMap(tableNameEncryptionContextOverrides)
         );
@@ -62,20 +77,40 @@ public class EncryptionContextOverridesWithDynamoDBMapper {
                 .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.CLOBBER).build();
         DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
 
-        System.out.println("Plaintext Record: " + record);
+        System.out.println("Plaintext Record: " + record.toString());
         // Save the record to the DynamoDB table
         mapper.save(record);
 
-        // Retrieve the encrypted record (directly without decrypting) from Dynamo so we can see it in our example
+        // Retrieve (and decrypt) it from DynamoDB
+        ExampleItem decrypted_record = mapper.load(ExampleItem.class, "is this", 55);
+        System.out.println("Decrypted Record: " + decrypted_record.toString());
+
+        // Setup new configuration to decrypt without using an overridden EncryptionContext
         final Map<String, AttributeValue> itemKey = new HashMap<>();
         itemKey.put("partition_attribute", new AttributeValue().withS("is this"));
         itemKey.put("sort_attribute", new AttributeValue().withN("55"));
-        System.out.println("Encrypted Record: " + ddb.getItem("ExampleTableForEncryptionContextOverrides",
-                itemKey).getItem());
 
-        // Retrieve (and decrypt) it from DynamoDB
-        ExampleItem decrypted_record = mapper.load(ExampleItem.class, "is this", 55);
-        System.out.println("Decrypted Record: " + decrypted_record);
+        final EnumSet<EncryptionFlags> signOnly = EnumSet.of(EncryptionFlags.SIGN);
+        final EnumSet<EncryptionFlags> encryptAndSign = EnumSet.of(EncryptionFlags.ENCRYPT, EncryptionFlags.SIGN);
+        final Map<String, AttributeValue> encryptedItem = ddb.getItem("ExampleTableForEncryptionContextOverrides", itemKey)
+                .getItem();
+        System.out.println("Encrypted Record: " + encryptedItem);
+
+        Map<String, Set<EncryptionFlags>> encryptionFlags = new HashMap<>();
+        encryptionFlags.put("partition_attribute", signOnly);
+        encryptionFlags.put("sort_attribute", signOnly);
+        encryptionFlags.put("example", encryptAndSign);
+
+        final DynamoDBEncryptor encryptorWithoutOverrides = DynamoDBEncryptor.getInstance(cmp);
+
+        // Decrypt the record without using an overridden EncryptionContext
+        encryptorWithoutOverrides.decryptRecord(encryptedItem,
+                encryptionFlags,
+                new EncryptionContext.Builder().withHashKeyName("partition_attribute")
+                        .withRangeKeyName("sort_attribute")
+                        .withTableName(newEncryptionContextTableName)
+                        .build());
+        System.out.printf("The example item was encrypted using the table name '%s' in the EncryptionContext%n", newEncryptionContextTableName);
     }
 
     @DynamoDBTable(tableName = "ExampleTableForEncryptionContextOverrides")
@@ -109,6 +144,11 @@ public class EncryptionContextOverridesWithDynamoDBMapper {
 
         public void setExample(String example) {
             this.example = example;
+        }
+
+        public String toString() {
+            return String.format("{partition_attribute: %s, sort_attribute: %s, example: %s}",
+                    partitionAttribute, sortAttribute, example);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
-        <version>1.11.434</version>
+        <version>1.11.460</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
@@ -9,6 +9,11 @@ import java.util.function.UnaryOperator;
  * Implementations of common operators for overriding the EncryptionContext
  */
 public class EncryptionContextOperators {
+
+    // Prevent instantiation
+    private EncryptionContextOperators() {
+    }
+
     /**
      * An operator for overriding EncryptionContext's table name for a specific DynamoDBEncryptor. If any table names or
      * the encryption context itself is null, then it returns the original EncryptionContext.
@@ -35,7 +40,6 @@ public class EncryptionContextOperators {
         };
     }
 
-
     /**
      * An operator for mapping multiple table names in the Encryption Context to a new table name. If the table name for
      * a given EncryptionContext is missing, then it returns the original EncryptionContext. Similarly, it returns the
@@ -60,6 +64,4 @@ public class EncryptionContextOperators {
             }
         };
     }
-
-
 }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
@@ -1,0 +1,65 @@
+package com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionContext;
+
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+/**
+ * Implementations of common operators for overriding the EncryptionContext
+ */
+public class EncryptionContextOperators {
+    /**
+     * An operator for overriding EncryptionContext's table name for a specific DynamoDBEncryptor. If any table names or
+     * the encryption context itself is null, then it returns the original EncryptionContext.
+     *
+     * @param originalTableName the name of the table that should be overridden in the Encryption Context
+     * @param newTableName the table name that should be used in the Encryption Context
+     * @return A UnaryOperator that produces a new EncryptionContext with the supplied table name
+     */
+    public static UnaryOperator<EncryptionContext> overrideEncryptionContextTableName(
+            String originalTableName,
+            String newTableName) {
+        return encryptionContext -> {
+            if (encryptionContext == null
+                    || encryptionContext.getTableName() == null
+                    || originalTableName == null
+                    || newTableName == null) {
+                return encryptionContext;
+            }
+            if (originalTableName.equals(encryptionContext.getTableName())) {
+                return new EncryptionContext.Builder(encryptionContext).withTableName(newTableName).build();
+            } else {
+                return encryptionContext;
+            }
+        };
+    }
+
+
+    /**
+     * An operator for mapping multiple table names in the Encryption Context to a new table name. If the table name for
+     * a given EncryptionContext is missing, then it returns the original EncryptionContext. Similarly, it returns the
+     * original EncryptionContext if the value it is overridden to is null, or if the original table name is null.
+     *
+     * @param tableNameOverrideMap a map specifying the names of tables that should be overridden,
+     *                             and the values to which they should be overridden. If the given table name
+     *                             corresponds to null, or isn't in the map, then the table name won't be overridden.
+     * @return A UnaryOperator that produces a new EncryptionContext with the supplied table name
+     */
+    public static UnaryOperator<EncryptionContext> overrideEncryptionContextTableNameUsingMap(
+            Map<String, String> tableNameOverrideMap) {
+        return encryptionContext -> {
+            if (tableNameOverrideMap == null || encryptionContext == null || encryptionContext.getTableName() == null) {
+                return encryptionContext;
+            }
+            String newTableName = tableNameOverrideMap.get(encryptionContext.getTableName());
+            if (newTableName != null) {
+                return new EncryptionContext.Builder(encryptionContext).withTableName(newTableName).build();
+            } else {
+                return encryptionContext;
+            }
+        };
+    }
+
+
+}

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperatorsTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperatorsTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 
 import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils.EncryptionContextOperators.overrideEncryptionContextTableName;
 import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils.EncryptionContextOperators.overrideEncryptionContextTableNameUsingMap;
@@ -15,7 +15,7 @@ public class EncryptionContextOperatorsTest {
 
     @Test
     public void testCreateEncryptionContextTableNameOverride_expectedOverride() {
-        UnaryOperator<EncryptionContext> myNewTableName = overrideEncryptionContextTableName("OriginalTableName", "MyNewTableName");
+        Function<EncryptionContext, EncryptionContext> myNewTableName = overrideEncryptionContextTableName("OriginalTableName", "MyNewTableName");
 
         EncryptionContext context = new EncryptionContext.Builder().withTableName("OriginalTableName").build();
 
@@ -56,7 +56,7 @@ public class EncryptionContextOperatorsTest {
         tableNameOverrides.put("OriginalTableName", "MyNewTableName");
 
 
-        UnaryOperator<EncryptionContext> nameOverrideMap =
+        Function<EncryptionContext, EncryptionContext> nameOverrideMap =
                 overrideEncryptionContextTableNameUsingMap(tableNameOverrides);
 
         EncryptionContext context = new EncryptionContext.Builder().withTableName("OriginalTableName").build();
@@ -74,7 +74,7 @@ public class EncryptionContextOperatorsTest {
         tableNameOverrides.put("OriginalTableName2", "MyNewTableName2");
 
 
-        UnaryOperator<EncryptionContext> overrideOperator =
+        Function<EncryptionContext, EncryptionContext> overrideOperator =
                 overrideEncryptionContextTableNameUsingMap(tableNameOverrides);
 
         EncryptionContext context = new EncryptionContext.Builder().withTableName("OriginalTableName1").build();
@@ -136,17 +136,15 @@ public class EncryptionContextOperatorsTest {
 
 
     private void assertEncryptionContextUnchanged(EncryptionContext encryptionContext, String originalTableName, String newTableName) {
-        UnaryOperator<EncryptionContext> encryptionContextTableNameOverride = overrideEncryptionContextTableName(originalTableName, newTableName);
+        Function<EncryptionContext, EncryptionContext> encryptionContextTableNameOverride = overrideEncryptionContextTableName(originalTableName, newTableName);
         EncryptionContext newEncryptionContext = encryptionContextTableNameOverride.apply(encryptionContext);
         assertEquals(encryptionContext, newEncryptionContext);
     }
 
 
     private void assertEncryptionContextUnchangedFromMap(EncryptionContext encryptionContext, Map<String, String> overrideMap) {
-        UnaryOperator<EncryptionContext> encryptionContextTableNameOverrideFromMap = overrideEncryptionContextTableNameUsingMap(overrideMap);
+        Function<EncryptionContext, EncryptionContext> encryptionContextTableNameOverrideFromMap = overrideEncryptionContextTableNameUsingMap(overrideMap);
         EncryptionContext newEncryptionContext = encryptionContextTableNameOverrideFromMap.apply(encryptionContext);
         assertEquals(encryptionContext, newEncryptionContext);
     }
-
-
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperatorsTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperatorsTest.java
@@ -1,0 +1,152 @@
+package com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionContext;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils.EncryptionContextOperators.overrideEncryptionContextTableName;
+import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils.EncryptionContextOperators.overrideEncryptionContextTableNameUsingMap;
+import static org.junit.Assert.*;
+
+public class EncryptionContextOperatorsTest {
+
+    @Test
+    public void testCreateEncryptionContextTableNameOverride_expectedOverride() {
+        UnaryOperator<EncryptionContext> myNewTableName = overrideEncryptionContextTableName("OriginalTableName", "MyNewTableName");
+
+        EncryptionContext context = new EncryptionContext.Builder().withTableName("OriginalTableName").build();
+
+        EncryptionContext newContext = myNewTableName.apply(context);
+
+        assertEquals("OriginalTableName", context.getTableName());
+        assertEquals("MyNewTableName", newContext.getTableName());
+    }
+
+    /**
+     * Some pretty clear repetition in null cases. May make sense to replace with data providers or parameterized
+     * classes for null cases
+     */
+    @Test
+    public void testNullCasesCreateEncryptionContextTableNameOverride_nullOriginalTableName() {
+        assertEncryptionContextUnchanged(new EncryptionContext.Builder().withTableName("example").build(),
+                null,
+                "MyNewTableName");
+    }
+
+    @Test
+    public void testCreateEncryptionContextTableNameOverride_differentOriginalTableName() {
+        assertEncryptionContextUnchanged(new EncryptionContext.Builder().withTableName("example").build(),
+                "DifferentTableName",
+                "MyNewTableName");
+    }
+
+    @Test
+    public void testNullCasesCreateEncryptionContextTableNameOverride_nullEncryptionContext() {
+        assertEncryptionContextUnchanged(null,
+                "DifferentTableName",
+                "MyNewTableName");
+    }
+
+    @Test
+    public void testCreateEncryptionContextTableNameOverrideMap_expectedOverride() {
+        Map<String, String> tableNameOverrides = new HashMap<>();
+        tableNameOverrides.put("OriginalTableName", "MyNewTableName");
+
+
+        UnaryOperator<EncryptionContext> nameOverrideMap =
+                overrideEncryptionContextTableNameUsingMap(tableNameOverrides);
+
+        EncryptionContext context = new EncryptionContext.Builder().withTableName("OriginalTableName").build();
+
+        EncryptionContext newContext = nameOverrideMap.apply(context);
+
+        assertEquals("OriginalTableName", context.getTableName());
+        assertEquals("MyNewTableName", newContext.getTableName());
+    }
+
+    @Test
+    public void testCreateEncryptionContextTableNameOverrideMap_multipleOverrides() {
+        Map<String, String> tableNameOverrides = new HashMap<>();
+        tableNameOverrides.put("OriginalTableName1", "MyNewTableName1");
+        tableNameOverrides.put("OriginalTableName2", "MyNewTableName2");
+
+
+        UnaryOperator<EncryptionContext> overrideOperator =
+                overrideEncryptionContextTableNameUsingMap(tableNameOverrides);
+
+        EncryptionContext context = new EncryptionContext.Builder().withTableName("OriginalTableName1").build();
+
+        EncryptionContext newContext = overrideOperator.apply(context);
+
+        assertEquals("OriginalTableName1", context.getTableName());
+        assertEquals("MyNewTableName1", newContext.getTableName());
+
+        EncryptionContext context2 = new EncryptionContext.Builder().withTableName("OriginalTableName2").build();
+
+        EncryptionContext newContext2 = overrideOperator.apply(context2);
+
+        assertEquals("OriginalTableName2", context2.getTableName());
+        assertEquals("MyNewTableName2", newContext2.getTableName());
+
+    }
+
+
+    @Test
+    public void testNullCasesCreateEncryptionContextTableNameOverrideFromMap_nullEncryptionContextTableName() {
+        Map<String, String> tableNameOverrides = new HashMap<>();
+        tableNameOverrides.put("DifferentTableName", "MyNewTableName");
+        assertEncryptionContextUnchangedFromMap(new EncryptionContext.Builder().build(),
+                tableNameOverrides);
+    }
+
+    @Test
+    public void testNullCasesCreateEncryptionContextTableNameOverrideFromMap_nullEncryptionContext() {
+        Map<String, String> tableNameOverrides = new HashMap<>();
+        tableNameOverrides.put("DifferentTableName", "MyNewTableName");
+        assertEncryptionContextUnchangedFromMap(null,
+                tableNameOverrides);
+    }
+
+
+    @Test
+    public void testNullCasesCreateEncryptionContextTableNameOverrideFromMap_nullOriginalTableName() {
+        Map<String, String> tableNameOverrides = new HashMap<>();
+        tableNameOverrides.put(null, "MyNewTableName");
+        assertEncryptionContextUnchangedFromMap(new EncryptionContext.Builder().withTableName("example").build(),
+                tableNameOverrides);
+    }
+
+    @Test
+    public void testNullCasesCreateEncryptionContextTableNameOverrideFromMap_nullNewTableName() {
+        Map<String, String> tableNameOverrides = new HashMap<>();
+        tableNameOverrides.put("MyOriginalTableName", null);
+        assertEncryptionContextUnchangedFromMap(new EncryptionContext.Builder().withTableName("MyOriginalTableName").build(),
+                tableNameOverrides);
+    }
+
+
+    @Test
+    public void testNullCasesCreateEncryptionContextTableNameOverrideFromMap_nullMap() {
+        assertEncryptionContextUnchangedFromMap(new EncryptionContext.Builder().withTableName("MyOriginalTableName").build(),
+                null);
+    }
+
+
+    private void assertEncryptionContextUnchanged(EncryptionContext encryptionContext, String originalTableName, String newTableName) {
+        UnaryOperator<EncryptionContext> encryptionContextTableNameOverride = overrideEncryptionContextTableName(originalTableName, newTableName);
+        EncryptionContext newEncryptionContext = encryptionContextTableNameOverride.apply(encryptionContext);
+        assertEquals(encryptionContext, newEncryptionContext);
+    }
+
+
+    private void assertEncryptionContextUnchangedFromMap(EncryptionContext encryptionContext, Map<String, String> overrideMap) {
+        UnaryOperator<EncryptionContext> encryptionContextTableNameOverrideFromMap = overrideEncryptionContextTableNameUsingMap(overrideMap);
+        EncryptionContext newEncryptionContext = encryptionContextTableNameOverrideFromMap.apply(encryptionContext);
+        assertEquals(encryptionContext, newEncryptionContext);
+    }
+
+
+}


### PR DESCRIPTION
There are people asking for overrides, and it would be better if they didn't
need to wait for longer term, internal refactors before they are able to use
overrides. This adds optional operators that give the client the last say on the
EncryptionContext's value.

Note: I haven't tested the example, since I didn't figure out a way to run them.
How are we running example code? If we don't have a suggested way yet, I can
figure something out and document it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
