### PR TITLE
Add testng and maven failsafe for integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,16 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>7.0.0-beta1</version>
       <scope>test</scope>
     </dependency>
 
@@ -178,6 +185,12 @@
         <version>2.22.1</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
+          <systemProperties>
+            <property>
+              <name>sqlite4java.library.path</name>
+              <value>${project.build.directory}/test-lib</value>
+            </property>
+          </systemProperties>
           <includes>
             <include>**/Test*.java</include>
             <include>**/*Test.java</include>
@@ -185,13 +198,32 @@
             <include>**/*Tests.java</include>
             <include>**/*TestCases.java</include>
           </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
           <systemProperties>
             <property>
               <name>sqlite4java.library.path</name>
               <value>${project.build.directory}/test-lib</value>
             </property>
           </systemProperties>
+          <includes>
+            <include>**/*ITCase.java</include>
+          </includes>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Add a dependency on testng for writing unit and integration tests. Soon, we will
migrate off of junit and onto testng. I've actually already made that change
locally, but it will be less painful to include that with a different cr.

Why maven failsafe? Maven failsafe is like maven surefire, but it ensures that
various cleanup is called when integration tests fail. It hooks into the
existing release workflow, so integration tests run before install or release.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
