### PR TITLE
Add maven failsafe plugin for running integration tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,32 @@
           </systemProperties>
         </configuration>
       </plugin>
+
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>3.0.0-M2</version>
+          <configuration>
+              <useSystemClassLoader>false</useSystemClassLoader>
+              <systemProperties>
+                  <property>
+                      <name>sqlite4java.library.path</name>
+                      <value>${project.build.directory}/test-lib</value>
+                  </property>
+              </systemProperties>
+              <includes>
+                  <include>**/*ITCase.java</include>
+              </includes>
+          </configuration>
+          <executions>
+              <execution>
+                  <goals>
+                      <goal>integration-test</goal>
+                      <goal>verify</goal>
+                  </goals>
+              </execution>
+          </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Add the maven failsafe plugin for running integration tests. Maven failsafe is
like maven surefire, but it ensures that various cleanup is called when
integration tests fail. It hooks into the existing release workflow, so
integration tests run before install or release.

The integration tests may be run through $mvn integration-test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
