### PR TITLE
Add ExtraDataSupplier to Metastore, and support for overriding KMS requests in DirectKMSMaterialProvider

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/store/MetaStore.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/store/MetaStore.java
@@ -148,7 +148,7 @@ public class MetaStore extends ProviderStore {
         this.ddbCtx = new EncryptionContext.Builder().withTableName(this.tableName)
                 .withHashKeyName(DEFAULT_HASH_KEY).withRangeKeyName(DEFAULT_RANGE_KEY).build();
 
-        final Map<String, ExpectedAttributeValue> tmpExpected = new HashMap<String, ExpectedAttributeValue>();
+        final Map<String, ExpectedAttributeValue> tmpExpected = new HashMap<>();
         tmpExpected.put(DEFAULT_HASH_KEY, new ExpectedAttributeValue().withExists(false));
         tmpExpected.put(DEFAULT_RANGE_KEY, new ExpectedAttributeValue().withExists(false));
         doesNotExist = Collections.unmodifiableMap(tmpExpected);
@@ -221,7 +221,7 @@ public class MetaStore extends ProviderStore {
     }
 
     private Map<String, AttributeValue> getMaterialItem(final String materialName, final long version) {
-        final Map<String, AttributeValue> ddbKey = new HashMap<String, AttributeValue>();
+        final Map<String, AttributeValue> ddbKey = new HashMap<>();
         ddbKey.put(DEFAULT_HASH_KEY, new AttributeValue().withS(materialName));
         ddbKey.put(DEFAULT_RANGE_KEY, new AttributeValue().withN(Long.toString(version)));
         final Map<String, AttributeValue> item = ddbGet(ddbKey);
@@ -294,7 +294,7 @@ public class MetaStore extends ProviderStore {
             ddb.putItem(put);
             return item;
         } catch (final ConditionalCheckFailedException ex) {
-            final Map<String, AttributeValue> ddbKey = new HashMap<String, AttributeValue>();
+            final Map<String, AttributeValue> ddbKey = new HashMap<>();
             ddbKey.put(DEFAULT_HASH_KEY, item.get(DEFAULT_HASH_KEY));
             ddbKey.put(DEFAULT_RANGE_KEY, item.get(DEFAULT_RANGE_KEY));
             return ddbGet(ddbKey);

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProviderTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProviderTest.java
@@ -20,6 +20,8 @@ import com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.Wrapp
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.testing.FakeKMS;
 import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.model.DecryptRequest;
+import com.amazonaws.services.kms.model.DecryptResult;
 import com.amazonaws.services.kms.model.GenerateDataKeyRequest;
 import com.amazonaws.services.kms.model.GenerateDataKeyResult;
 import com.amazonaws.util.Base64;
@@ -50,7 +52,7 @@ public class DirectKmsMaterialProviderTest {
 
     @BeforeMethod
     public void setUp() {
-        description = new HashMap<String, String>();
+        description = new HashMap<>();
         description.put("TestKey", "test value");
         description = Collections.unmodifiableMap(description);
         ctx = new EncryptionContext.Builder().build();
@@ -87,7 +89,7 @@ public class DirectKmsMaterialProviderTest {
     public void simpleWithKmsEc() throws GeneralSecurityException {
         DirectKmsMaterialProvider prov = new DirectKmsMaterialProvider(kms, keyId);
 
-        Map<String, AttributeValue> attrVals = new HashMap<String, AttributeValue>();
+        Map<String, AttributeValue> attrVals = new HashMap<>();
         attrVals.put("hk", new AttributeValue("HashKeyValue"));
         attrVals.put("rk", new AttributeValue("RangeKeyValue"));
 
@@ -116,7 +118,7 @@ public class DirectKmsMaterialProviderTest {
     public void simpleWithKmsEc2() throws GeneralSecurityException {
         DirectKmsMaterialProvider prov = new DirectKmsMaterialProvider(kms, keyId);
 
-        Map<String, AttributeValue> attrVals = new HashMap<String, AttributeValue>();
+        Map<String, AttributeValue> attrVals = new HashMap<>();
         attrVals.put("hk", new AttributeValue().withN("10"));
         attrVals.put("rk", new AttributeValue().withN("20"));
 
@@ -145,7 +147,7 @@ public class DirectKmsMaterialProviderTest {
     public void simpleWithKmsEc3() throws GeneralSecurityException {
         DirectKmsMaterialProvider prov = new DirectKmsMaterialProvider(kms, keyId);
 
-        Map<String, AttributeValue> attrVals = new HashMap<String, AttributeValue>();
+        Map<String, AttributeValue> attrVals = new HashMap<>();
         attrVals.put("hk",
                 new AttributeValue().withB(ByteBuffer.wrap("Foo".getBytes(StandardCharsets.UTF_8))));
         attrVals.put("rk",
@@ -198,7 +200,7 @@ public class DirectKmsMaterialProviderTest {
 
     @Test
     public void explicitContentKeyAlgorithm() throws GeneralSecurityException {
-        Map<String, String> desc = new HashMap<String, String>();
+        Map<String, String> desc = new HashMap<>();
         desc.put(WrappedRawMaterials.CONTENT_KEY_ALGORITHM, "AES");
 
         DirectKmsMaterialProvider prov = new DirectKmsMaterialProvider(kms, keyId, desc);
@@ -215,7 +217,7 @@ public class DirectKmsMaterialProviderTest {
 
     @Test
     public void explicitContentKeyLength128() throws GeneralSecurityException {
-        Map<String, String> desc = new HashMap<String, String>();
+        Map<String, String> desc = new HashMap<>();
         desc.put(WrappedRawMaterials.CONTENT_KEY_ALGORITHM, "AES/128");
 
         DirectKmsMaterialProvider prov = new DirectKmsMaterialProvider(kms, keyId, desc);
@@ -234,7 +236,7 @@ public class DirectKmsMaterialProviderTest {
 
     @Test
     public void explicitContentKeyLength256() throws GeneralSecurityException {
-        Map<String, String> desc = new HashMap<String, String>();
+        Map<String, String> desc = new HashMap<>();
         desc.put(WrappedRawMaterials.CONTENT_KEY_ALGORITHM, "AES/256");
 
         DirectKmsMaterialProvider prov = new DirectKmsMaterialProvider(kms, keyId, desc);
@@ -336,7 +338,7 @@ public class DirectKmsMaterialProviderTest {
     }
 
     private static class ExtendedKmsMaterialProvider extends DirectKmsMaterialProvider {
-        protected final String encryptionKeyIdAttributeName;
+        private final String encryptionKeyIdAttributeName;
 
         public ExtendedKmsMaterialProvider(AWSKMS kms, String encryptionKeyId, String encryptionKeyIdAttributeName) {
             super(kms, encryptionKeyId);
@@ -364,6 +366,16 @@ public class DirectKmsMaterialProviderTest {
             if (!customEncryptionKeyId.equals(encryptionKeyId)) {
                 throw new DynamoDBMappingException("encryption key ids do not match.");
             }
+        }
+
+        @Override
+        protected DecryptResult decrypt(DecryptRequest request, EncryptionContext context) {
+            return super.decrypt(request, context);
+        }
+
+        @Override
+        protected GenerateDataKeyResult generateDataKey(GenerateDataKeyRequest request, EncryptionContext context) {
+            return super.generateDataKey(request, context);
         }
     }
 

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/store/MetaStoreTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/store/MetaStoreTests.java
@@ -286,7 +286,7 @@ public class MetaStoreTests {
         store.getProvider(MATERIAL_NAME, 1000);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void invalidSignedOnlyField() {
         final Map<String, AttributeValue> attributeValueMap = new HashMap<>();
         attributeValueMap.put("enc", new AttributeValue().withS("testEncryptionKey"));

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/store/MetaStoreTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/store/MetaStoreTests.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.Encry
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers.EncryptionMaterialsProvider;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers.SymmetricStaticProvider;
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -31,6 +32,10 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -58,6 +63,28 @@ public class MetaStoreTests {
     private MetaStore store;
     private MetaStore targetStore;
     private EncryptionContext ctx;
+
+    private static class TestExtraDataSupplier implements MetaStore.ExtraDataSupplier {
+
+        private final Map<String, AttributeValue> attributeValueMap;
+        private final Set<String> signedOnlyFieldNames;
+
+        public TestExtraDataSupplier(final Map<String, AttributeValue> attributeValueMap,
+                                     final Set<String> signedOnlyFieldNames) {
+            this.attributeValueMap = attributeValueMap;
+            this.signedOnlyFieldNames = signedOnlyFieldNames;
+        }
+
+        @Override
+        public Map<String, AttributeValue> getAttributes(String materialName, long version) {
+            return this.attributeValueMap;
+        }
+
+        @Override
+        public Set<String> getSignedOnlyFieldNames() {
+            return this.signedOnlyFieldNames;
+        }
+    }
 
     @BeforeMethod
     public void setup() {
@@ -182,6 +209,34 @@ public class MetaStoreTests {
     }
 
     @Test
+    public void getOrCreateWithContextSupplier() {
+        final Map<String, AttributeValue> attributeValueMap = new HashMap<>();
+        attributeValueMap.put("CustomKeyId", new AttributeValue().withS("testCustomKeyId"));
+        attributeValueMap.put("KeyToken", new AttributeValue().withS("testKeyToken"));
+
+        final Set<String> signedOnlyAttributes = new HashSet<>();
+        signedOnlyAttributes.add("CustomKeyId");
+
+        final TestExtraDataSupplier extraDataSupplier = new TestExtraDataSupplier(
+                attributeValueMap, signedOnlyAttributes);
+
+        final MetaStore metaStore = new MetaStore(client, SOURCE_TABLE_NAME, ENCRYPTOR, extraDataSupplier);
+
+        assertEquals(-1, metaStore.getMaxVersion(MATERIAL_NAME));
+        final EncryptionMaterialsProvider prov1 = metaStore.getOrCreate(MATERIAL_NAME, 0);
+        assertEquals(0, metaStore.getMaxVersion(MATERIAL_NAME));
+        final EncryptionMaterialsProvider prov2 = metaStore.getOrCreate(MATERIAL_NAME, 0);
+
+        final EncryptionMaterials eMat = prov1.getEncryptionMaterials(ctx);
+        final SecretKey encryptionKey = eMat.getEncryptionKey();
+        assertNotNull(encryptionKey);
+
+        final DecryptionMaterials dMat = prov2.getDecryptionMaterials(ctx(eMat));
+        assertEquals(encryptionKey, dMat.getDecryptionKey());
+        assertEquals(eMat.getSigningKey(), dMat.getVerificationKey());
+    }
+
+    @Test
     public void replicateIntermediateKeysTest() {
         assertEquals(-1, store.getMaxVersion(MATERIAL_NAME));
 
@@ -229,6 +284,20 @@ public class MetaStoreTests {
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
     public void invalidVersion() {
         store.getProvider(MATERIAL_NAME, 1000);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidSignedOnlyField() {
+        final Map<String, AttributeValue> attributeValueMap = new HashMap<>();
+        attributeValueMap.put("enc", new AttributeValue().withS("testEncryptionKey"));
+
+        final Set<String> signedOnlyAttributes = new HashSet<>();
+        signedOnlyAttributes.add("enc");
+
+        final TestExtraDataSupplier extraDataSupplier = new TestExtraDataSupplier(
+                attributeValueMap, signedOnlyAttributes);
+
+        new MetaStore(client, SOURCE_TABLE_NAME, ENCRYPTOR, extraDataSupplier);
     }
 
     private static EncryptionContext ctx(final EncryptionMaterials mat) {


### PR DESCRIPTION
Failed check from Travis is expected because JDK11 recently stopped working on Travis (nothing to do with our code).

This is a near direct copy of DirectKMS and MetaStore. Commit 4e682ea is a direct copy of the internal metastore and DirectKMSMaterialProvider. There will probably need to be a minor update to this to get it to work with testng.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
