### PR TITLE
Add JaCoCo and Codecov and fix travis to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
   - openjdk11
   - oraclejdk8
 install: /bin/true
-script: mvn install
+script: mvn install --quiet
 after_success:
+  # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ jdk:
   - openjdk11
   - oraclejdk8
 install: /bin/true
-script: mvn install --quiet -Dgpg.skip=true -DskipTests=true
+script: mvn install
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ jdk:
   - oraclejdk8
 install: /bin/true
 script: mvn install --quiet -Dgpg.skip=true -DskipTests=true
-
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,26 @@
               </execution>
           </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -258,7 +278,7 @@
                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
             </configuration>
           </plugin>
-     
+
        </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Add JaCoCo which generates jacoco.exec files and xml reports of code coverage. Add Codecov's hosted bash script for uploading the reports on travis. More importantly, fix travis to run tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
