### PR TITLE
Switch to Java 8's Base64 Implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,14 @@
         <version>6.10</version>
         <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.quicktheories</groupId>
+      <artifactId>quicktheories</artifactId>
+      <version>0.25</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-all</artifactId>

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/materials/WrappedRawMaterials.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/materials/WrappedRawMaterials.java
@@ -14,6 +14,15 @@
  */
 package com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DelegatedKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.internal.Base64;
+import com.amazonaws.services.dynamodbv2.datamodeling.internal.Utils;
+
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -21,16 +30,6 @@ import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.Map;
-
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.KeyGenerator;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
-
-import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DelegatedKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.internal.Utils;
-import com.amazonaws.util.Base64;
 
 /**
  * Represents cryptographic materials used to manage unique record-level keys.
@@ -136,7 +135,7 @@ public class WrappedRawMaterials extends AbstractRawMaterials {
                     description.get(KEY_WRAPPING_ALGORITHM) :
                     getTransformation(wrappingKey.getAlgorithm());
             byte[] encryptedKey = wrapKey(key, wrappingAlg);
-            description.put(ENVELOPE_KEY, Base64.encodeAsString(encryptedKey));
+            description.put(ENVELOPE_KEY, Base64.encodeToString(encryptedKey));
             description.put(CONTENT_KEY_ALGORITHM, key.getAlgorithm());
             description.put(KEY_WRAPPING_ALGORITHM, wrappingAlg);
             setMaterialDescription(description);

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProvider.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProvider.java
@@ -14,19 +14,6 @@
  */
 package com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers;
 
-import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.CONTENT_KEY_ALGORITHM;
-import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.ENVELOPE_KEY;
-import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.KEY_WRAPPING_ALGORITHM;
-
-import java.nio.ByteBuffer;
-import java.security.NoSuchAlgorithmException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionContext;
@@ -34,6 +21,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.Decry
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.EncryptionMaterials;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.SymmetricRawMaterials;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials;
+import com.amazonaws.services.dynamodbv2.datamodeling.internal.Base64;
 import com.amazonaws.services.dynamodbv2.datamodeling.internal.Hkdf;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.kms.AWSKMS;
@@ -41,9 +29,20 @@ import com.amazonaws.services.kms.model.DecryptRequest;
 import com.amazonaws.services.kms.model.DecryptResult;
 import com.amazonaws.services.kms.model.GenerateDataKeyRequest;
 import com.amazonaws.services.kms.model.GenerateDataKeyResult;
-import com.amazonaws.util.Base64;
 import com.amazonaws.util.StringUtils;
 import com.amazonaws.util.VersionInfoUtils;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.CONTENT_KEY_ALGORITHM;
+import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.ENVELOPE_KEY;
+import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.KEY_WRAPPING_ALGORITHM;
 
 /**
  * Generates a unique data key for each record in DynamoDB and protects that key
@@ -175,7 +174,7 @@ public class DirectKmsMaterialProvider implements EncryptionMaterialsProvider {
         materialDescription.put(KEY_WRAPPING_ALGORITHM, "kms");
         materialDescription.put(CONTENT_KEY_ALGORITHM, dataKeyDesc);
         materialDescription.put(SIGNING_KEY_ALGORITHM, sigKeyDesc);
-        materialDescription.put(ENVELOPE_KEY, Base64.encodeAsString(toArray(dataKeyResult.getCiphertextBlob())));
+        materialDescription.put(ENVELOPE_KEY, Base64.encodeToString(toArray(dataKeyResult.getCiphertextBlob())));
 
         final Hkdf kdf;
         try {
@@ -241,7 +240,7 @@ public class DirectKmsMaterialProvider implements EncryptionMaterialsProvider {
             } else if (hashKey.getS() != null) {
                 kmsEc.put(hashKeyName, hashKey.getS());
             } else if (hashKey.getB() != null) {
-                kmsEc.put(hashKeyName, Base64.encodeAsString(toArray(hashKey.getB())));
+                kmsEc.put(hashKeyName, Base64.encodeToString(toArray(hashKey.getB())));
             } else {
                 throw new UnsupportedOperationException("DirectKmsMaterialProvider only supports String, Number, and Binary HashKeys");
             }
@@ -254,7 +253,7 @@ public class DirectKmsMaterialProvider implements EncryptionMaterialsProvider {
             } else if (rangeKey.getS() != null) {
                 kmsEc.put(rangeKeyName, rangeKey.getS());
             } else if (rangeKey.getB() != null) {
-                kmsEc.put(rangeKeyName, Base64.encodeAsString(toArray(rangeKey.getB())));
+                kmsEc.put(rangeKeyName, Base64.encodeToString(toArray(rangeKey.getB())));
             } else {
                 throw new UnsupportedOperationException("DirectKmsMaterialProvider only supports String, Number, and Binary RangeKeys");
             }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Base64.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Base64.java
@@ -1,0 +1,35 @@
+package com.amazonaws.services.dynamodbv2.datamodeling.internal;
+
+import java.util.Base64.Decoder;
+import java.util.Base64.Encoder;
+
+/**
+ * A class for decoding Base64 strings and encoding bytes as Base64 strings.
+ */
+public class Base64 {
+    private static final Decoder DECODER = java.util.Base64.getMimeDecoder();
+    private static final Encoder ENCODER = java.util.Base64.getEncoder();
+
+    private Base64() { }
+
+    /**
+     * Encode the bytes as a Base64 string.
+     * <p>
+     * See the Basic encoder in {@link java.util.Base64}
+     */
+    public static String encodeToString(byte[] bytes) {
+        return ENCODER.encodeToString(bytes);
+    }
+
+    /**
+     * Decode the Base64 string as bytes, ignoring illegal characters.
+     * <p>
+     * See the Mime Decoder in {@link java.util.Base64}
+     */
+    public static byte[] decode(String str) {
+        if(str == null) {
+            return null;
+        }
+        return DECODER.decode(str);
+    }
+}

--- a/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Base64Tests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Base64Tests.java
@@ -1,0 +1,90 @@
+package com.amazonaws.services.dynamodbv2.datamodeling.internal;
+
+import org.apache.commons.lang3.StringUtils;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.Generate.byteArrays;
+import static org.quicktheories.generators.Generate.bytes;
+import static org.quicktheories.generators.SourceDSL.integers;
+
+/**
+ * Tests for the Base64 interface used by the DynamoDBEncryptionClient
+ */
+public class Base64Tests {
+
+    @Test
+    public void testBase64EncodeEquivalence() {
+        qt().forAll(byteArrays(integers().between(0, 1000000),
+                bytes(Byte.MIN_VALUE, Byte.MAX_VALUE, (byte) 0)))
+                .check((a) -> {
+                    // Base64 encode using both implementations and check for equality of output
+                    // in case one version produces different output
+                    String sdk1Base64 = com.amazonaws.util.Base64.encodeAsString(a);
+                    String encryptionClientBase64 = Base64.encodeToString(a);
+                    return StringUtils.equals(sdk1Base64, encryptionClientBase64);
+                });
+    }
+
+    @Test
+    public void testBase64DecodeEquivalence() {
+        qt().forAll(byteArrays(integers().between(0, 10000),
+                bytes(Byte.MIN_VALUE, Byte.MAX_VALUE, (byte) 0)))
+                .as((b) -> java.util.Base64.getMimeEncoder().encodeToString(b))
+                .check((s) -> {
+                    // Check for equality using the MimeEncoder, which inserts newlines
+                    // The encryptionClient's decoder is expected to ignore them
+                    byte[] sdk1Bytes = com.amazonaws.util.Base64.decode(s);
+                    byte[] encryptionClientBase64 = Base64.decode(s);
+                    return Arrays.equals(sdk1Bytes, encryptionClientBase64);
+                });
+    }
+
+    @Test
+    public void testNullDecodeBehavior() {
+        byte[] decoded = Base64.decode(null);
+        assertThat(decoded, equalTo(null));
+    }
+
+    @Test
+    public void testNullDecodeBehaviorSdk1() {
+        byte[] decoded = com.amazonaws.util.Base64.decode((String) null);
+        assertThat(decoded, equalTo(null));
+
+        byte[] decoded2 = com.amazonaws.util.Base64.decode((byte[]) null);
+        assertThat(decoded2, equalTo(null));
+    }
+
+    @Test
+    public void testBase64PaddingBehavior() {
+        String testInput = "another one bites the dust";
+        String expectedEncoding = "YW5vdGhlciBvbmUgYml0ZXMgdGhlIGR1c3Q=";
+        assertThat(Base64.encodeToString(testInput.getBytes(StandardCharsets.UTF_8)), equalTo(expectedEncoding));
+
+        String encodingWithoutPadding = "YW5vdGhlciBvbmUgYml0ZXMgdGhlIGR1c3Q";
+        assertThat(Base64.decode(encodingWithoutPadding), equalTo(testInput.getBytes()));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBase64PaddingBehaviorSdk1() {
+        String testInput = "another one bites the dust";
+        String encodingWithoutPadding = "YW5vdGhlciBvbmUgYml0ZXMgdGhlIGR1c3Q";
+        com.amazonaws.util.Base64.decode(encodingWithoutPadding);
+    }
+
+    @Test
+    public void rfc4648TestVectors() {
+        assertThat(Base64.encodeToString("".getBytes(StandardCharsets.UTF_8)), equalTo(""));
+        assertThat(Base64.encodeToString("f".getBytes(StandardCharsets.UTF_8)), equalTo("Zg=="));
+        assertThat(Base64.encodeToString("fo".getBytes(StandardCharsets.UTF_8)), equalTo("Zm8="));
+        assertThat(Base64.encodeToString("foo".getBytes(StandardCharsets.UTF_8)), equalTo("Zm9v"));
+        assertThat(Base64.encodeToString("foob".getBytes(StandardCharsets.UTF_8)), equalTo("Zm9vYg=="));
+        assertThat(Base64.encodeToString("fooba".getBytes(StandardCharsets.UTF_8)), equalTo("Zm9vYmE="));
+        assertThat(Base64.encodeToString("foobar".getBytes(StandardCharsets.UTF_8)), equalTo("Zm9vYmFy"));
+    }
+}


### PR DESCRIPTION
This replaces the Base64 implementation in the DynamoDB Encryption
Client with Java 8's Base64 Basic encoder and Mime decoder.

It also includes compatibility tests with the original Base64
encoder/decoder. The new encoder is just as strict about its output,
and more permissive with its input.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
