### PR TITLE
Add SCM connection metadata to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
 
   <scm>
     <url>https://github.com/aws/aws-dynamodb-encryption-java.git</url>
+    <connection>scm:git:git@github.com:aws/aws-dynamodb-encryption-java.git</connection>
+    <developerConnection>scm:git:git@github.com:aws/aws-dynamodb-encryption-java.git</developerConnection>
   </scm>
   
   <properties>


### PR DESCRIPTION
This adds connection metadata, which helps with tools that need to know where to
retrieve the source code of jars.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
