### PR TITLE
Shorten the overrides example

### DIFF
--- a/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
+++ b/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
@@ -7,36 +7,36 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DynamoDBEncryptor;
-import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionContext;
-import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionFlags;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers.DirectKmsMaterialProvider;
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils.EncryptionContextOperators;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
 
 import java.security.GeneralSecurityException;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-
-import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils.EncryptionContextOperators.overrideEncryptionContextTableNameUsingMap;
 
 public class EncryptionContextOverridesWithDynamoDBMapper {
+
+    private static DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder()
+            .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.PUT).build();
+
     public static void main(String[] args) throws GeneralSecurityException {
         final String cmkArn = args[0];
         final String region = args[1];
-        final String encryptionContextTableName = args[2];
 
         AmazonDynamoDB ddb = null;
         AWSKMS kms = null;
         try {
             ddb = AmazonDynamoDBClientBuilder.standard().withRegion(region).build();
             kms = AWSKMSClientBuilder.standard().withRegion(region).build();
-            encryptRecord(cmkArn, encryptionContextTableName, ddb, kms);
+            encryptRecord(cmkArn, ddb, kms);
         } finally {
             if (ddb != null) {
                 ddb.shutdown();
@@ -48,107 +48,73 @@ public class EncryptionContextOverridesWithDynamoDBMapper {
     }
 
     public static void encryptRecord(final String cmkArn,
-                                     final String newEncryptionContextTableName,
                                      AmazonDynamoDB ddb,
                                      AWSKMS kms) throws GeneralSecurityException {
-        // Sample object to be encrypted
-        ExampleItem record = new ExampleItem();
-        record.setPartitionAttribute("is this");
-        record.setSortAttribute(55);
-        record.setExample("my data");
+        final String dynamoTableName = "DuckTable";
+        final String dynamoBackupName = "DuckBackup";
 
-        // Set up our configuration and clients
+        DuckPojo duckPojo = new DuckPojo();
+        duckPojo.setDuckName("Quackley");
+        duckPojo.setSwimming(true);
+
         final DirectKmsMaterialProvider cmp = new DirectKmsMaterialProvider(kms, cmkArn);
         final DynamoDBEncryptor encryptor = DynamoDBEncryptor.getInstance(cmp);
 
-        Map<String, String> tableNameEncryptionContextOverrides = new HashMap<>();
-        tableNameEncryptionContextOverrides.put("ExampleTableForEncryptionContextOverrides", newEncryptionContextTableName);
-        tableNameEncryptionContextOverrides.put("AnotherExampleTableForEncryptionContextOverrides", "this table doesn't exist");
+        encryptor.setEncryptionContextOverrideOperator(EncryptionContextOperators.overrideEncryptionContextTableName(
+                dynamoBackupName, dynamoTableName));
 
-        // Supply an operator to override the table name used in the encryption context
-        encryptor.setEncryptionContextOverrideOperator(
-                overrideEncryptionContextTableNameUsingMap(tableNameEncryptionContextOverrides)
-        );
-
-        // Mapper Creation
-        // Please note the use of SaveBehavior.PUT (SaveBehavior.CLOBBER works as well).
-        // Omitting this can result in data-corruption.
-        DynamoDBMapperConfig mapperConfig = DynamoDBMapperConfig.builder()
-                .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.PUT).build();
         DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
 
-        System.out.println("Plaintext Record: " + record.toString());
-        // Save the record to the DynamoDB table
-        mapper.save(record);
+        // Encrypt and save the record to the DuckTable
+        mapper.save(duckPojo);
 
-        // Retrieve (and decrypt) it from DynamoDB
-        ExampleItem decrypted_record = mapper.load(ExampleItem.class, "is this", 55);
-        System.out.println("Decrypted Record: " + decrypted_record.toString());
+        // Copy the encrypted record to the backup
+        copyRecordsToBackup(ddb, dynamoTableName, dynamoBackupName);
 
-        // Setup new configuration to decrypt without using an overridden EncryptionContext
-        final Map<String, AttributeValue> itemKey = new HashMap<>();
-        itemKey.put("partition_attribute", new AttributeValue().withS("is this"));
-        itemKey.put("sort_attribute", new AttributeValue().withN("55"));
-
-        final EnumSet<EncryptionFlags> signOnly = EnumSet.of(EncryptionFlags.SIGN);
-        final EnumSet<EncryptionFlags> encryptAndSign = EnumSet.of(EncryptionFlags.ENCRYPT, EncryptionFlags.SIGN);
-        final Map<String, AttributeValue> encryptedItem = ddb.getItem("ExampleTableForEncryptionContextOverrides", itemKey)
-                .getItem();
-        System.out.println("Encrypted Record: " + encryptedItem);
-
-        Map<String, Set<EncryptionFlags>> encryptionFlags = new HashMap<>();
-        encryptionFlags.put("partition_attribute", signOnly);
-        encryptionFlags.put("sort_attribute", signOnly);
-        encryptionFlags.put("example", encryptAndSign);
-
-        final DynamoDBEncryptor encryptorWithoutOverrides = DynamoDBEncryptor.getInstance(cmp);
-
-        // Decrypt the record without using an overridden EncryptionContext
-        encryptorWithoutOverrides.decryptRecord(encryptedItem,
-                encryptionFlags,
-                new EncryptionContext.Builder().withHashKeyName("partition_attribute")
-                        .withRangeKeyName("sort_attribute")
-                        .withTableName(newEncryptionContextTableName)
-                        .build());
-        System.out.printf("The example item was encrypted using the table name '%s' in the EncryptionContext%n", newEncryptionContextTableName);
+        // Load and decrypt using the backup. Without using the override, decryption fails.
+        mapper.load(duckPojo, DynamoDBMapperConfig.builder()
+                .withTableNameOverride(DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement(dynamoBackupName))
+                .build());
     }
 
-    @DynamoDBTable(tableName = "ExampleTableForEncryptionContextOverrides")
-    public static final class ExampleItem {
-        private String partitionAttribute;
-        private int sortAttribute;
-        private String example;
+    public static void copyRecordsToBackup(AmazonDynamoDB dynamoDB, String mainTableName, String backupName) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("duckName", new AttributeValue().withS("Quackley"));
 
-        @DynamoDBHashKey(attributeName = "partition_attribute")
-        public String getPartitionAttribute() {
-            return partitionAttribute;
+        GetItemRequest getItemRequest = new GetItemRequest(mainTableName, key);
+        GetItemResult item = dynamoDB.getItem(getItemRequest);
+
+        PutItemRequest putItemRequest = new PutItemRequest();
+        putItemRequest.withTableName(backupName);
+        putItemRequest.withItem(item.getItem());
+        dynamoDB.putItem(putItemRequest);
+    }
+
+    @DynamoDBTable(tableName = "DuckTable")
+    public static final class DuckPojo {
+        private String duckName;
+        private boolean swimming;
+
+        @DynamoDBHashKey(attributeName = "duckName")
+        public String getDuckName() {
+            return duckName;
         }
 
-        public void setPartitionAttribute(String partitionAttribute) {
-            this.partitionAttribute = partitionAttribute;
+        public void setDuckName(String duckName) {
+            this.duckName = duckName;
         }
 
-        @DynamoDBRangeKey(attributeName = "sort_attribute")
-        public int getSortAttribute() {
-            return sortAttribute;
+        @DynamoDBAttribute
+        public boolean isSwimming() {
+            return swimming;
         }
 
-        public void setSortAttribute(int sortAttribute) {
-            this.sortAttribute = sortAttribute;
-        }
-
-        @DynamoDBAttribute(attributeName = "example")
-        public String getExample() {
-            return example;
-        }
-
-        public void setExample(String example) {
-            this.example = example;
+        public void setSwimming(boolean swimming) {
+            this.swimming = swimming;
         }
 
         public String toString() {
-            return String.format("{partition_attribute: %s, sort_attribute: %s, example: %s}",
-                    partitionAttribute, sortAttribute, example);
+            return String.format("{duck_name: %s, swimming: %s}", duckName, swimming);
         }
     }
 

--- a/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
+++ b/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
@@ -62,6 +62,8 @@ public class EncryptionContextOverridesWithDynamoDBMapper {
 
         encryptor.setEncryptionContextOverrideOperator(EncryptionContextOperators.overrideEncryptionContextTableName(
                 dynamoBackupName, dynamoTableName));
+        // EncryptionContextOperators.overrideEncryptionContextTableNameUsingMap may also be used to create overrides
+        // for several tables
 
         DynamoDBMapper mapper = new DynamoDBMapper(ddb, mapperConfig, new AttributeEncryptor(encryptor));
 


### PR DESCRIPTION
This adds an example that adds an encrypted record using the mapper, and loads from backup using encryption context operators.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
