### PR TITLE
Add Sdk2 DynamoDBEncryptor example for encrypting records with KMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
       <module>common</module>
       <module>sdk1</module>
       <module>sdk2</module>
+      <module>sdk2examples</module>
       <module>examples</module>
   </modules>
 

--- a/sdk2examples/pom.xml
+++ b/sdk2examples/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>software.amazon.cryptools</groupId>
+        <artifactId>dynamodbencryptionclient-pom</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>dynamodbencryptionclient-sdk2examples</artifactId>
+    <packaging>jar</packaging>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>aws-dynamodb-encryption-java :: SDK2 Examples</name>
+    <description>AWS DynamoDB Encryption Client for AWS Java SDK v2 Examples</description>
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.cryptools</groupId>
+            <artifactId>dynamodbencryptionclient-sdk2</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/sdk2examples/src/main/java/software/amazon/cryptools/dynamodbencryptionclientsdk2examples/AwsKmsEncryptedItem.java
+++ b/sdk2examples/src/main/java/software/amazon/cryptools/dynamodbencryptionclientsdk2examples/AwsKmsEncryptedItem.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.cryptools.dynamodbencryptionclientsdk2examples;
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.cryptools.dynamodbencryptionclientsdk2.DynamoDBEncryptor;
+import software.amazon.cryptools.dynamodbencryptionclientsdk2.configuration.DynamoDBEncryptionConfiguration;
+import software.amazon.cryptools.dynamodbencryptionclientsdk2.encryptioncontext.EncryptionContext;
+import software.amazon.cryptools.dynamodbencryptionclientsdk2.providers.DirectKmsMaterialsProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AwsKmsEncryptedItem {
+    public static void main(String[] args) {
+        KmsClient kmsClient = KmsClient.create();
+        String arn = "";
+        Map<String, String> description = new HashMap<>();
+        String tableName = "ExampleTable";
+        DynamoDbClient dynamoDbClient = DynamoDbClient.create();
+
+        encryptRecord(kmsClient, dynamoDbClient, arn, description, tableName);
+    }
+
+
+    public static void encryptRecord(final KmsClient kmsClient,
+                                     final DynamoDbClient dynamoDbClient,
+                                     final String arn,
+                                     final Map<String, String> description,
+                                     final String tableName) {
+        DirectKmsMaterialsProvider kmsMaterialsProvider = new DirectKmsMaterialsProvider(kmsClient, arn, description);
+        DynamoDBEncryptor encryptor = new DynamoDBEncryptor(kmsMaterialsProvider);
+
+        Map<String, AttributeValue> record = new HashMap<>();
+        record.put("id", AttributeValue.builder().n("100").build());
+        record.put("protectedName", AttributeValue.builder().s("Jeff").build());
+
+        Map<String, AttributeValue> encryptedRecord = encryptor.encryptRecord(record,
+                DynamoDBEncryptionConfiguration.builder()
+                        .withEncryptionContext(EncryptionContext.builder()
+                                .withTableName(tableName)
+                                .withHashKeyName("id").build())
+                        .build());
+
+        PutItemRequest putItemRequest = PutItemRequest.builder()
+                .item(encryptedRecord)
+                .tableName(tableName)
+                .build();
+
+        dynamoDbClient.putItem(putItemRequest);
+    }
+}


### PR DESCRIPTION
This adds a draft example of SDK2's DynamoDBEncryptor's usage. It is expected to not compile until the other components are completed, and will change if the interfaces change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
