### PR TITLE
Add Checkstyle with License Check to Build, and add missing headers

### DIFF
--- a/ddej-build-tools/pom.xml
+++ b/ddej-build-tools/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>software.amazon.cryptools</groupId>
+    <artifactId>ddej-build-tools</artifactId>
+    <version>0.1.0</version>
+    <name>aws-dynamodb-encryption-java :: Build Tools</name>
+    <description>Houses configuration for checkstyle</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ddej-build-tools/src/main/resources/software/amazon/cryptools/ddej-build-tools/checkstyle/checkstyle-suppressions.xml
+++ b/ddej-build-tools/src/main/resources/software/amazon/cryptools/ddej-build-tools/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+          "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+          "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+</suppressions>

--- a/ddej-build-tools/src/main/resources/software/amazon/cryptools/ddej-build-tools/checkstyle/checkstyle.xml
+++ b/ddej-build-tools/src/main/resources/software/amazon/cryptools/ddej-build-tools/checkstyle/checkstyle.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="error"/>
+    <property name="fileExtensions" value="java"/>
+    <module name="RegexpHeader">
+        <property name="header"
+                  value="^/*\n * Copyright \d{4} Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.$"/>
+    </module>
+</module>

--- a/examples/com/amazonaws/examples/AsymmetricEncryptedItem.java
+++ b/examples/com/amazonaws/examples/AsymmetricEncryptedItem.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.examples;
 
 import java.nio.ByteBuffer;

--- a/examples/com/amazonaws/examples/AwsKmsEncryptedItem.java
+++ b/examples/com/amazonaws/examples/AwsKmsEncryptedItem.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.examples;
 
 import java.nio.ByteBuffer;

--- a/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
+++ b/examples/com/amazonaws/examples/AwsKmsEncryptedObject.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.examples;
 
 import java.security.GeneralSecurityException;

--- a/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
+++ b/examples/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.examples;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;

--- a/examples/com/amazonaws/examples/MostRecentEncryptedItem.java
+++ b/examples/com/amazonaws/examples/MostRecentEncryptedItem.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.examples;
 
 import java.nio.ByteBuffer;

--- a/examples/com/amazonaws/examples/SymmetricEncryptedItem.java
+++ b/examples/com/amazonaws/examples/SymmetricEncryptedItem.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.examples;
 
 import java.nio.ByteBuffer;

--- a/pom.xml
+++ b/pom.xml
@@ -241,27 +241,27 @@
             <logViolationsToConsole>true</logViolationsToConsole>
             <failOnViolation>true</failOnViolation>
         </configuration>
-    </plugin>
+      </plugin>
 
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
-          <configuration>
-              <useSystemClassLoader>false</useSystemClassLoader>
-              <systemProperties>
-                  <property>
-                      <name>sqlite4java.library.path</name>
-                      <value>${project.build.directory}/test-lib</value>
-                  </property>
-              </systemProperties>
-              <includes>
-                  <include>**/*ITCase.java</include>
-              </includes>
-          </configuration>
-          <executions>
-              <execution>
-                  <goals>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
+        <configuration>
+            <useSystemClassLoader>false</useSystemClassLoader>
+            <systemProperties>
+                <property>
+                    <name>sqlite4java.library.path</name>
+                    <value>${project.build.directory}/test-lib</value>
+                </property>
+            </systemProperties>
+            <includes>
+                <include>**/*ITCase.java</include>
+            </includes>
+        </configuration>
+        <executions>
+            <execution>
+                <goals>
                       <goal>integration-test</goal>
                       <goal>verify</goal>
                   </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
   </scm>
 
   <modules>
+      <module>ddej-build-tools</module>
       <module>common</module>
       <module>sdk1</module>
       <module>sdk2</module>
@@ -37,6 +38,15 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sqlite4java.version>1.0.392</sqlite4java.version>
+    <checkstyle.version>8.17</checkstyle.version>
+    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+    <ddej-build-tools.version>0.1.0</ddej-build-tools.version>
+    <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
+    <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+    <maven-jxr-plugin.version>3.0.0</maven-jxr-plugin.version>
+    <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
   </properties>
 
   <developers>
@@ -179,7 +189,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
           <includes>
@@ -199,9 +209,44 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <dependencies>
+            <dependency>
+                <groupId>com.puppycrawl.tools</groupId>
+                <artifactId>checkstyle</artifactId>
+                <version>${checkstyle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.cryptools</groupId>
+                <artifactId>ddej-build-tools</artifactId>
+                <version>${ddej-build-tools.version}</version>
+            </dependency>
+        </dependencies>
+        <executions>
+            <execution>
+                <id>checkstyle</id>
+                <phase>validate</phase>
+                <goals>
+                    <goal>check</goal>
+                </goals>
+            </execution>
+        </executions>
+        <configuration>
+            <configLocation>software/amazon/cryptools/ddej-build-tools/checkstyle/checkstyle.xml</configLocation>
+            <suppressionsLocation>software/amazon/cryptools/ddej-build-tools/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
+            <consoleOutput>true</consoleOutput>
+            <failsOnError>true</failsOnError>
+            <logViolationsToConsole>true</logViolationsToConsole>
+            <failOnViolation>true</failOnViolation>
+        </configuration>
+    </plugin>
+
+      <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>${maven-failsafe-plugin.version}</version>
           <configuration>
               <useSystemClassLoader>false</useSystemClassLoader>
               <systemProperties>
@@ -227,7 +272,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
+        <version>${jacoco-maven-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -245,4 +290,14 @@
       </plugin>
     </plugins>
   </build>
+
+  <reporting>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jxr-plugin</artifactId>
+              <version>${maven-jxr-plugin.version}</version>
+          </plugin>
+      </plugins>
+  </reporting>
 </project>

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.services.dynamodbv2.datamodeling.encryption.utils;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionContext;

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Utils.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Utils.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.services.dynamodbv2.datamodeling.internal;
 
 import java.security.SecureRandom;


### PR DESCRIPTION
Before, we didn't have any automated checks for license headers. This adds a check that fails the build if there is a missing license.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
