### PR TITLE
Allow DoNotEncrypt/DoNotTouch field level annotations

### DIFF
--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
@@ -207,7 +207,8 @@ public class AttributeEncryptor implements AttributeTransformer {
      * @return True if {@link DoNotTouch} IS present on the getter level. False otherwise.
      */
     private boolean doNotTouch(Mapping mapping) {
-        return mapping.getter().isAnnotationPresent(DoNotTouch.class);
+        return StandardAnnotationMaps.of(mapping.getter(), null)
+            .actualOf(DoNotTouch.class) != null;
     }
 
     /**
@@ -228,7 +229,8 @@ public class AttributeEncryptor implements AttributeTransformer {
      * @return True if {@link DoNotEncrypt} IS present on the getter level. False otherwise.
      */
     private boolean doNotEncrypt(Mapping mapping) {
-        return mapping.getter().isAnnotationPresent(DoNotEncrypt.class);
+        return StandardAnnotationMaps.of(mapping.getter(), null)
+            .actualOf(DoNotEncrypt.class) != null;
     }
 
     /**

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotEncrypt.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotEncrypt.java
@@ -19,11 +19,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDB;
+
 /**
  * Prevents the associated item (class or attribute) from being encrypted.
  * 
  * @author Greg Rubin 
  */
+@DynamoDB
 @Target(value = {ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface DoNotEncrypt {

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotEncrypt.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotEncrypt.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
  * 
  * @author Greg Rubin 
  */
-@Target(value = {ElementType.TYPE, ElementType.METHOD})
+@Target(value = {ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface DoNotEncrypt {
 

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotTouch.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotTouch.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
  * 
  * @author Greg Rubin 
  */
-@Target(value = {ElementType.TYPE, ElementType.METHOD})
+@Target(value = {ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface DoNotTouch {
 

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotTouch.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotTouch.java
@@ -19,11 +19,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDB;
+
 /**
  * Prevents the associated item from being encrypted or signed.
  * 
  * @author Greg Rubin 
  */
+@DynamoDB
 @Target(value = {ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface DoNotTouch {

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptorTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptorTest.java
@@ -526,7 +526,7 @@ public class AttributeEncryptorTest {
         params = FakeParameters.getInstance(
             DoNotTouchField.class, encryptedAttributes, null,
             TABLE_NAME, HASH_KEY, RANGE_KEY);
-        encryptedAttributes.get("value").setN("200");
+        encryptedAttributes.put("value", new AttributeValue().withN("200"));
         Map<String, AttributeValue> decryptedAttributes = encryptor.untransform(params);
         assertThat(decryptedAttributes, AttrMatcher.invert(attributes));
         assertAttrEquals(new AttributeValue().withN("200"), decryptedAttributes.get("value"));

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/DoNotEncryptField.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/DoNotEncryptField.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.testing.types;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DoNotEncrypt;
+
+@DynamoDBTable(tableName = "TableName")
+public class DoNotEncryptField {
+    @DynamoDBHashKey
+    int hashKey;
+    @DynamoDBRangeKey
+    int rangeKey;
+    @DoNotEncrypt
+    int value;
+
+    public DoNotEncryptField() {
+    }
+
+    public DoNotEncryptField(int hashKey, int rangeKey) {
+        this.hashKey = hashKey;
+        this.rangeKey = rangeKey;
+    }
+
+    public int getRangeKey() {
+        return rangeKey;
+    }
+
+    public void setRangeKey(int rangeKey) {
+        this.rangeKey = rangeKey;
+    }
+
+    public int getHashKey() {
+        return hashKey;
+    }
+
+    public void setHashKey(int hashKey) {
+        this.hashKey = hashKey;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + hashKey;
+        result = prime * result + rangeKey;
+        result = prime * result + value;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DoNotEncryptField other = (DoNotEncryptField) obj;
+        if (hashKey != other.hashKey)
+            return false;
+        if (rangeKey != other.rangeKey)
+            return false;
+        if (value != other.value)
+            return false;
+        return true;
+    }
+}

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/DoNotEncryptField.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/DoNotEncryptField.java
@@ -14,43 +14,14 @@
  */
 package com.amazonaws.services.dynamodbv2.testing.types;
 
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DoNotEncrypt;
 
 @DynamoDBTable(tableName = "TableName")
-public class DoNotEncryptField {
-    @DynamoDBHashKey
-    int hashKey;
-    @DynamoDBRangeKey
-    int rangeKey;
+public class DoNotEncryptField extends Mixed {
+
     @DoNotEncrypt
     int value;
-
-    public DoNotEncryptField() {
-    }
-
-    public DoNotEncryptField(int hashKey, int rangeKey) {
-        this.hashKey = hashKey;
-        this.rangeKey = rangeKey;
-    }
-
-    public int getRangeKey() {
-        return rangeKey;
-    }
-
-    public void setRangeKey(int rangeKey) {
-        this.rangeKey = rangeKey;
-    }
-
-    public int getHashKey() {
-        return hashKey;
-    }
-
-    public void setHashKey(int hashKey) {
-        this.hashKey = hashKey;
-    }
 
     public int getValue() {
         return value;
@@ -62,12 +33,7 @@ public class DoNotEncryptField {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + hashKey;
-        result = prime * result + rangeKey;
-        result = prime * result + value;
-        return result;
+        return 31 * super.hashCode() + value;
     }
 
     @Override
@@ -79,10 +45,6 @@ public class DoNotEncryptField {
         if (getClass() != obj.getClass())
             return false;
         DoNotEncryptField other = (DoNotEncryptField) obj;
-        if (hashKey != other.hashKey)
-            return false;
-        if (rangeKey != other.rangeKey)
-            return false;
         if (value != other.value)
             return false;
         return true;

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/DoNotTouchField.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/DoNotTouchField.java
@@ -14,43 +14,14 @@
  */
 package com.amazonaws.services.dynamodbv2.testing.types;
 
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DoNotTouch;
 
 @DynamoDBTable(tableName = "TableName")
-public class DoNotTouchField {
-    @DynamoDBHashKey
-    int hashKey;
-    @DynamoDBRangeKey
-    int rangeKey;
+public class DoNotTouchField extends Mixed {
+
     @DoNotTouch
     int value;
-
-    public DoNotTouchField() {
-    }
-
-    public DoNotTouchField(int hashKey, int rangeKey) {
-        this.hashKey = hashKey;
-        this.rangeKey = rangeKey;
-    }
-
-    public int getRangeKey() {
-        return rangeKey;
-    }
-
-    public void setRangeKey(int rangeKey) {
-        this.rangeKey = rangeKey;
-    }
-
-    public int getHashKey() {
-        return hashKey;
-    }
-
-    public void setHashKey(int hashKey) {
-        this.hashKey = hashKey;
-    }
 
     public int getValue() {
         return value;
@@ -62,12 +33,7 @@ public class DoNotTouchField {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + hashKey;
-        result = prime * result + rangeKey;
-        result = prime * result + value;
-        return result;
+        return 31 * super.hashCode() + value;
     }
 
     @Override
@@ -79,10 +45,6 @@ public class DoNotTouchField {
         if (getClass() != obj.getClass())
             return false;
         DoNotTouchField other = (DoNotTouchField) obj;
-        if (hashKey != other.hashKey)
-            return false;
-        if (rangeKey != other.rangeKey)
-            return false;
         if (value != other.value)
             return false;
         return true;

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/DoNotTouchField.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/testing/types/DoNotTouchField.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.testing.types;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DoNotTouch;
+
+@DynamoDBTable(tableName = "TableName")
+public class DoNotTouchField {
+    @DynamoDBHashKey
+    int hashKey;
+    @DynamoDBRangeKey
+    int rangeKey;
+    @DoNotTouch
+    int value;
+
+    public DoNotTouchField() {
+    }
+
+    public DoNotTouchField(int hashKey, int rangeKey) {
+        this.hashKey = hashKey;
+        this.rangeKey = rangeKey;
+    }
+
+    public int getRangeKey() {
+        return rangeKey;
+    }
+
+    public void setRangeKey(int rangeKey) {
+        this.rangeKey = rangeKey;
+    }
+
+    public int getHashKey() {
+        return hashKey;
+    }
+
+    public void setHashKey(int hashKey) {
+        this.hashKey = hashKey;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + hashKey;
+        result = prime * result + rangeKey;
+        result = prime * result + value;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DoNotTouchField other = (DoNotTouchField) obj;
+        if (hashKey != other.hashKey)
+            return false;
+        if (rangeKey != other.rangeKey)
+            return false;
+        if (value != other.value)
+            return false;
+        return true;
+    }
+}


### PR DESCRIPTION
https://github.com/aws/aws-dynamodb-encryption-java/issues/94

Inspect potential field level annotations using StandardAnnotationMaps when deciding whether to touch/encrypt an attribute

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
