### PR TITLE
Remove oraclejdk8 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 jdk:
   - openjdk8
   - openjdk11
-  - oraclejdk8
 install: /bin/true
 script: mvn install --quiet
 after_success:


### PR DESCRIPTION
Oracle JDK8 is broken on travis through no fault of the client code. Removing so that
we can commit to this repository without continuously failing CI.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

