### PR TITLE
Allow overriding KMS encryption context.

### DIFF
--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProvider.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProvider.java
@@ -254,7 +254,8 @@ public class DirectKmsMaterialProvider implements EncryptionMaterialsProvider {
 
     /**
      * Extracts relevant information from {@code context} and uses it to populate fields in
-     * {@code kmsEc}. Currently, these fields are:
+     * {@code kmsEc}. Subclass can override the default implementation to provide an alternative
+     * encryption context in calls to KMS. Currently, the default implementation includes these fields:
      * <dl>
      * <dt>{@code HashKeyName}</dt>
      * <dd>{@code HashKeyValue}</dd>
@@ -263,7 +264,7 @@ public class DirectKmsMaterialProvider implements EncryptionMaterialsProvider {
      * <dt>{@link #TABLE_NAME_EC_KEY}</dt>
      * <dd>{@code TableName}</dd>
      */
-    private static void populateKmsEcFromEc(EncryptionContext context, Map<String, String> kmsEc) {
+    protected void populateKmsEcFromEc(EncryptionContext context, Map<String, String> kmsEc) {
         final String hashKeyName = context.getHashKeyName();
         if (hashKeyName != null) {
             final AttributeValue hashKey = context.getAttributeValues().get(hashKeyName);

--- a/sdk2/src/main/java/software/amazon/cryptools/dynamodbencryptionclientsdk2/encryption/providers/DirectKmsMaterialsProvider.java
+++ b/sdk2/src/main/java/software/amazon/cryptools/dynamodbencryptionclientsdk2/encryption/providers/DirectKmsMaterialsProvider.java
@@ -246,7 +246,8 @@ public class DirectKmsMaterialsProvider implements EncryptionMaterialsProvider {
 
     /**
      * Extracts relevant information from {@code context} and uses it to populate fields in
-     * {@code kmsEc}. Currently, these fields are:
+     * {@code kmsEc}. Subclass can override the default implementation to provide an alternative
+     * encryption context in calls to KMS. Currently, the default implementation includes these fields:
      * <dl>
      * <dt>{@code HashKeyName}</dt>
      * <dd>{@code HashKeyValue}</dd>
@@ -255,7 +256,7 @@ public class DirectKmsMaterialsProvider implements EncryptionMaterialsProvider {
      * <dt>{@link #TABLE_NAME_EC_KEY}</dt>
      * <dd>{@code TableName}</dd>
      */
-    private static void populateKmsEcFromEc(EncryptionContext context, Map<String, String> kmsEc) {
+    protected void populateKmsEcFromEc(EncryptionContext context, Map<String, String> kmsEc) {
         final String hashKeyName = context.getHashKeyName();
         if (hashKeyName != null) {
             final AttributeValue hashKey = context.getAttributeValues().get(hashKeyName);


### PR DESCRIPTION
*Description of changes:*

We have a need to provide our own encryption context for calls to KMS. This change makes the `populateKmsEcFromEc` method of `DirectKmsMaterialsProvider` protected so we can override it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

