### PR TITLE
Update snapshot URL

### DIFF
--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-dynamodb-encryption-java</artifactId>
-    <version>1.14.0</version>
+    <version>1.14.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>aws-dynamodb-encryption-java :: SDK1</name>
     <description>AWS DynamoDB Encryption Client for AWS Java SDK v1</description>
@@ -50,7 +50,7 @@
             <distributionManagement>
                 <snapshotRepository>
                     <id>sonatype-nexus-staging</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://aws.oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
             </distributionManagement>
 


### PR DESCRIPTION
Moving to the aws.oss.sonatype endpoint. Needed to do some testing in
advance of the 1.4.1 patch release.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

