### PR TITLE
Update changelog for 1.14.1 (Patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
+## 1.14.1 -- 2019-10-14
+Fixes `com.amazonaws:aws-dynamodb-encryption-java` so that it may be consumed
+in mavenCentral.
 ## 1.14.0 -- 2019-10-14
+Use 1.14.1 instead. This release relies on a dependency that isn't
+available in mavenCentral.
 
 ### Minor Changes
 * Add ExtraDataSupplier to Metastore #76
@@ -7,7 +12,7 @@
 * Allow DoNotEncrypt and DoNotTouch to be used at a field level #95
 * Allow overriding KMS encryption context #102
 
-### Maintanence
+### Maintenance
 * Migrate from JUnit to TestNG
 * Added JaCoCo for code coverage
 * Replace Base64 implementation with Java 8's #82


### PR DESCRIPTION
1.14.0 can't be consumed by most clients, since it has a dependency that
isn't available in mavenCentral (the dependency is the parent pom in
this repository, if you are curious). If you were thinking of using
1.14.0, use 1.14.1 instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

