### PR TITLE
Fix for new versions of gpg

### DIFF
--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -37,6 +37,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
*Description of changes:*
Newer versions of gpg fail signing with the following error message:
`gpg: signing failed: Inappropriate ioctl for device`

This can be fixed by explicitly telling gpg to ask the caller for the passphrase/pin, rather than letting to attempt to query for it out of band to a human directly (which doesn't exist). On the command line it is done by adding the arguments `--pinentry-mode loopback`. This change tells maven to pass in these new arguments.

This has been tested with as part of building, signing and releasing version 1.6.1 of the aws-encryption-sdk-java.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

