### PR TITLE
Upgrade Bouncy Castle from 1.61 to 1.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ available in mavenCentral.
 * Added JaCoCo for code coverage
 * Replace Base64 implementation with Java 8's #82
 * Added checkstyle
+* Upgrade Bouncy Castle from 1.61 to 1.65 #119
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-ext-jdk15on</artifactId>
-      <version>1.60</version>
+      <version>1.65</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
*Issue #, if available:* #118 

*Description of changes:* Updating Bouncy Castle to the latest version (1.65)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

