### PR TITLE
Fix release date of 2.0.1 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 2.0.1 -- 2021-02-11
+## 2.0.1 -- 2021-02-12
 ### Bugfix
 Fixes released jar files to ensure JDK 8 compatibility.
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

