### PR TITLE
Read record without a amzn-ddb-map-desc

### DIFF
--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptor.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptor.java
@@ -237,6 +237,11 @@ public class DynamoDBEncryptor {
         if (attributeFlags.isEmpty()) {
             return itemAttributes;
         }
+        if (itemAttributes != null
+              && !itemAttributes.containsKey(DEFAULT_SIGNATURE_FIELD)
+              && !itemAttributes.containsKey(DEFAULT_METADATA_FIELD)) {
+            return itemAttributes;
+        }
         // Copy to avoid changing anyone elses objects
         itemAttributes = new HashMap<String, AttributeValue>(itemAttributes);
         


### PR DESCRIPTION

*Issue #, if available:*
https://github.com/aws/aws-dynamodb-encryption-java/issues/123

*Description of changes:*
Read record without an `amzn-ddb-map-desc`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [NO] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

