### PR TITLE
fix: Update user agent string to correctly reflect version

### DIFF
--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -272,6 +272,13 @@
     </repositories>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProvider.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProvider.java
@@ -34,11 +34,13 @@ import com.amazonaws.util.VersionInfoUtils;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.CONTENT_KEY_ALGORITHM;
 import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.ENVELOPE_KEY;
@@ -53,9 +55,8 @@ import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.material
  * @see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/encrypt-context.html">KMS Encryption Context</a>
  */
 public class DirectKmsMaterialProvider implements EncryptionMaterialsProvider {
-    private static final String VERSION_STRING = "1.0";
-    private static final String USER_AGENT = DirectKmsMaterialProvider.class.getName()
-            + "/" + VERSION_STRING + "/" + VersionInfoUtils.getVersion();
+    static final String USER_AGENT_PREFIX = "DynamodbEncryptionSdkJava/";
+    private static final String USER_AGENT = USER_AGENT_PREFIX + loadVersion();
     private static final String COVERED_ATTR_CTX_KEY = "aws-kms-ec-attr";
     private static final String SIGNING_KEY_ALGORITHM = "amzn-ddb-sig-alg";
     private static final String TABLE_NAME_EC_KEY = "*aws-kms-table*";
@@ -76,6 +77,17 @@ public class DirectKmsMaterialProvider implements EncryptionMaterialsProvider {
     private final String sigKeyAlg;
     private final int sigKeyLength;
     private final String sigKeyDesc;
+
+    private static String loadVersion() {
+        try {
+            final Properties properties = new Properties();
+            properties.load(DirectKmsMaterialProvider.class.getClassLoader()
+                    .getResourceAsStream("project.properties"));
+            return properties.getProperty("foo");
+        } catch (final IOException ex) {
+            return "unknown";
+        }
+    }
 
     public DirectKmsMaterialProvider(AWSKMS kms) {
         this(kms, null);

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProvider.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProvider.java
@@ -30,21 +30,19 @@ import com.amazonaws.services.kms.model.DecryptResult;
 import com.amazonaws.services.kms.model.GenerateDataKeyRequest;
 import com.amazonaws.services.kms.model.GenerateDataKeyResult;
 import com.amazonaws.util.StringUtils;
-import com.amazonaws.util.VersionInfoUtils;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.CONTENT_KEY_ALGORITHM;
 import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.ENVELOPE_KEY;
 import static com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.WrappedRawMaterials.KEY_WRAPPING_ALGORITHM;
+import static com.amazonaws.services.dynamodbv2.datamodeling.internal.Utils.loadVersion;
 
 /**
  * Generates a unique data key for each record in DynamoDB and protects that key
@@ -77,17 +75,6 @@ public class DirectKmsMaterialProvider implements EncryptionMaterialsProvider {
     private final String sigKeyAlg;
     private final int sigKeyLength;
     private final String sigKeyDesc;
-
-    private static String loadVersion() {
-        try {
-            final Properties properties = new Properties();
-            properties.load(DirectKmsMaterialProvider.class.getClassLoader()
-                    .getResourceAsStream("project.properties"));
-            return properties.getProperty("foo");
-        } catch (final IOException ex) {
-            return "unknown";
-        }
-    }
 
     public DirectKmsMaterialProvider(AWSKMS kms) {
         this(kms, null);

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Utils.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Utils.java
@@ -14,7 +14,9 @@
  */
 package com.amazonaws.services.dynamodbv2.datamodeling.internal;
 
+import java.io.IOException;
 import java.security.SecureRandom;
+import java.util.Properties;
 
 public class Utils {
     private static final ThreadLocal<SecureRandom> RND = new ThreadLocal<SecureRandom>() {
@@ -47,4 +49,18 @@ public class Utils {
             return ref;
         }
     }
+
+    /*
+     * Loads the version of the library
+     */
+    public static String loadVersion() {
+        try {
+            final Properties properties = new Properties();
+            properties.load(ClassLoader.getSystemResourceAsStream("project.properties"));
+            return properties.getProperty("version");
+        } catch (final IOException ex) {
+            return "unknown";
+        }
+    }
+
 }

--- a/sdk1/src/main/resources/project.properties
+++ b/sdk1/src/main/resources/project.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProviderTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/DirectKmsMaterialProviderTest.java
@@ -12,6 +12,7 @@
  */
 package com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers;
 
+import com.amazonaws.RequestClientOptions;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.EncryptionContext;
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.materials.DecryptionMaterials;
@@ -335,6 +336,19 @@ public class DirectKmsMaterialProviderTest {
         assertFalse(gdkCalled.get());
         new DirectKmsMaterialProvider(kmsSpy, keyId).getEncryptionMaterials(ctx);
         assertTrue(gdkCalled.get());
+    }
+
+    @Test
+    public void userAgentIsAdded() {
+        AWSKMS kmsSpy = new FakeKMS() {
+            @Override
+            public GenerateDataKeyResult generateDataKey(GenerateDataKeyRequest r) {
+                assertTrue(r.getRequestClientOptions().getClientMarker(RequestClientOptions.Marker.USER_AGENT)
+                        .contains(DirectKmsMaterialProvider.USER_AGENT_PREFIX));
+                return super.generateDataKey(r);
+            }
+        };
+        new DirectKmsMaterialProvider(kmsSpy, keyId).getEncryptionMaterials(ctx);
     }
 
     private static class ExtendedKmsMaterialProvider extends DirectKmsMaterialProvider {


### PR DESCRIPTION
*Description of changes:*
Update user agent string to show the correct DDBEC library version. Previously, we had a) never updated the version string of our library from `1.0`, and b) were needlessly including the version of the AWS Java SDK (this is already added as part of the user agent string by the SDK).

Rather than adding another place we have to hardcode the correct version, I'm pulling it from pom.xml.

I've also updated the format of our appended string to more closely match what we do in Python DDBEC and Java ESDK.

*Testing:*
This gives us a full user agent string like the following:

`aws-sdk-java/1.11.460 Mac_OS_X/10.15.7 OpenJDK_64-Bit_Server_VM/11.0.5+10-b520.38 java/11.0.5 DynamodbEncryptionSdkJava/2.0.1`

(First section is generated by AWS SDK, last section is ours)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
