### PR TITLE
ci: create release builds that validate on multiple JDKs

### DIFF
--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -5,7 +5,6 @@ version: 0.2
 #  --region us-west-2 \
 #  --project-name java-ddb-ec-release \
 #  --environment-variables-override name=VERSION,value=<INSERT_VERSION>,type=PLAINTEXT name=COMMIT_ID,value=<INSERT_COMMIT_ID>,type=PLAINTEXT"
-# TODO: Create Project java-ddb-ec-release
 
 env:
   secrets-manager:

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# 'release-prod' is an AWS::CodeBuild::Project that Releases to Sonatype and then validates the release with 'validate-prod'
+# 'release-prod' is an AWS::CodeBuild::BuildSpec that Releases to Sonatype and then validates the release with 'validate-prod'
 # Command to trigger this codebuild from an authorized command line.
 #  aws codebuild start-build-batch \
 #  --region us-west-2 \

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# 'release-prod' is an AWS::CodeBuild::Project that Releases from CodeArtifact to Sonatype and then validates the release with 'validate-prod'
+# 'release-prod' is an AWS::CodeBuild::Project that Releases to Sonatype and then validates the release with 'validate-prod'
 # Command to trigger this codebuild from an authorized command line.
 #  aws codebuild start-build-batch \
 #  --region us-west-2 \
@@ -20,7 +20,7 @@ phases:
   pre_build:
     commands:
       - git checkout $COMMIT_ID
-      - FOUND_VERSION=$(grep version pom.xml | head -n 2 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+      - FOUND_VERSION=$(grep version sdk1/pom.xml | head -n 2 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -1,0 +1,88 @@
+version: 0.2
+# 'release-prod' is an AWS::CodeBuild::Project that Releases from CodeArtifact to Sonatype and then validates the release with 'validate-prod'
+# Command to trigger this codebuild from an authorized command line.
+#  aws codebuild start-build-batch \
+#  --region us-west-2 \
+#  --project-name java-ddb-ec-release \
+#  --environment-variables-override name=VERSION,value=<INSERT_VERSION>,type=PLAINTEXT name=COMMIT_ID,value=<INSERT_COMMIT_ID>,type=PLAINTEXT"
+# TODO: Create Project java-ddb-ec-release
+
+env:
+  secrets-manager:
+    GPG_KEY: Maven-GPG-Keys-Credentials:Keyname
+    GPG_PASS: Maven-GPG-Keys-Credentials:Passphrase
+    SONA_USERNAME: Sonatype-Team-Account:Username 
+    SONA_PASSWORD: Sonatype-Team-Account:Password
+
+phases:
+  install:
+    runtime-versions:
+      java: openjdk8
+  pre_build:
+    commands:
+      - git checkout $COMMIT_ID
+      - FOUND_VERSION=$(grep version pom.xml | head -n 2 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+      - |
+        if expr ${FOUND_VERSION} != ${VERSION}; then
+          echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
+          exit 1;
+        fi
+      - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - tar -xvf ~/mvn_gpg.tgz -C ~
+  build:
+    commands:
+      - |
+        mvn deploy \
+          -Ppublishing \
+          -Pfast-tests-only \
+          -DperformRelease \
+          -Dgpg.homedir="$HOME/mvn_gpg" \
+          -DautoReleaseAfterClose=true \
+          -Dgpg.keyname="$GPG_KEY" \
+          -Dgpg.passphrase="$GPG_PASS" \
+          -Dsonatype.username="$SONA_USERNAME" \
+          -Dsonatype.password="$SONA_PASSWORD" \
+          -s $SETTINGS_FILE
+
+
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: release_to_prod
+    - identifier: validate_prod_release_openjdk8
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate-prod.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: openjdk8
+          JAVA_NUMERIC_VERSION: 8
+        image: aws/codebuild/standard:3.0
+    - identifier: validate_prod_release_openjdk11
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate-prod.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: openjdk11
+          JAVA_NUMERIC_VERSION: 11
+        image: aws/codebuild/standard:3.0
+    - identifier: validate_prod_release_corretto8
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate-prod.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: corretto8
+          JAVA_NUMERIC_VERSION: 8
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    - identifier: validate_prod_release_corretto11
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate-prod.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: corretto11
+          JAVA_NUMERIC_VERSION: 11
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -34,7 +34,6 @@ phases:
       - |
         mvn deploy \
           -Ppublishing \
-          -Pfast-tests-only \
           -DperformRelease \
           -Dgpg.homedir="$HOME/mvn_gpg" \
           -DautoReleaseAfterClose=true \

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -1,0 +1,92 @@
+version: 0.2
+# 'release-staging' is an AWS::CodeBuild::Project that Stages a release on CodeArtifact and validates the staging using 'validate-staging'
+# Command to trigger this codebuild from an authorized command line.
+# aws codebuild start-build-batch \
+#         --region us-west-2 \
+#         --project-name java-ddbec-test-release \
+#         --environment-variables-override name=VERSION,value=<INSERT_VERSION>,type=PLAINTEXT name=COMMIT_ID,value=<INSERT_COMMIT_ID>,type=PLAINTEXT
+
+env:
+  variables:
+    REGION: us-east-1
+    DOMAIN: crypto-tools-internal
+    REPOSITORY: java-ddbec-staging
+  parameter-store:
+    ACCOUNT: /CodeBuild/AccountId
+  secrets-manager:
+    GPG_KEY: Maven-GPG-Keys-Credentials:Keyname
+    GPG_PASS: Maven-GPG-Keys-Credentials:Passphrase
+
+phases:
+  install:
+    runtime-versions:
+      java: openjdk8
+  pre_build:
+    commands:
+      - git checkout $COMMIT_ID
+      - FOUND_VERSION=$(grep version pom.xml | head -n 2 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+      - |
+        if expr ${FOUND_VERSION} != ${VERSION}; then
+          echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
+          exit 1;
+        fi
+      - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
+      - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
+      - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - tar -xvf ~/mvn_gpg.tgz -C ~
+  build:
+    commands:
+      - |
+        mvn deploy \
+          -PpublishingCodeArtifact \
+          -Pfast-tests-only \
+          -DperformRelease \
+          -Dgpg.homedir="$HOME/mvn_gpg" \
+          -DautoReleaseAfterClose=true \
+          -Dgpg.keyname="$GPG_KEY" \
+          -Dgpg.passphrase="$GPG_PASS" \
+          -Dcodeartifact.token=$CODEARTIFACT_TOKEN \
+          -DaltDeploymentRepository=codeartifact::default::$CODEARTIFACT_REPO_URL \
+          -s $SETTINGS_FILE
+
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: release_to_staging
+    - identifier: validate_staging_release_openjdk8
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate-staging.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: openjdk8
+          JAVA_NUMERIC_VERSION: 8
+        image: aws/codebuild/standard:3.0
+    - identifier: validate_staging_release_openjdk11
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate-staging.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: openjdk11
+          JAVA_NUMERIC_VERSION: 11
+        image: aws/codebuild/standard:3.0
+    - identifier: validate_staging_release_corretto8
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate-staging.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: corretto8
+          JAVA_NUMERIC_VERSION: 8
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    - identifier: validate_staging_release_corretto11
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate-staging.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: corretto11
+          JAVA_NUMERIC_VERSION: 11
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -3,7 +3,7 @@ version: 0.2
 # Command to trigger this codebuild from an authorized command line.
 # aws codebuild start-build-batch \
 #         --region us-west-2 \
-#         --project-name java-ddbec-test-release \
+#         --project-name java-ddb-ec-test-release \
 #         --environment-variables-override name=VERSION,value=<INSERT_VERSION>,type=PLAINTEXT name=COMMIT_ID,value=<INSERT_COMMIT_ID>,type=PLAINTEXT
 
 env:

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -24,7 +24,7 @@ phases:
   pre_build:
     commands:
       - git checkout $COMMIT_ID
-      - FOUND_VERSION=$(grep version pom.xml | head -n 2 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+      - FOUND_VERSION=$(grep version sdk1/pom.xml | head -n 2 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
       - |
         if expr ${FOUND_VERSION} != ${VERSION}; then
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# 'release-staging' is an AWS::CodeBuild::Project that Stages a release on CodeArtifact and validates the staging using 'validate-staging'
+# 'release-staging' is an AWS::CodeBuild::BuildSpec that Stages a release on CodeArtifact and validates the staging using 'validate-staging'
 # Command to trigger this codebuild from an authorized command line.
 # aws codebuild start-build-batch \
 #         --region us-west-2 \

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -40,7 +40,6 @@ phases:
       - |
         mvn deploy \
           -PpublishingCodeArtifact \
-          -Pfast-tests-only \
           -DperformRelease \
           -Dgpg.homedir="$HOME/mvn_gpg" \
           -DautoReleaseAfterClose=true \

--- a/codebuild/release/settings.xml
+++ b/codebuild/release/settings.xml
@@ -1,0 +1,31 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                  http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>codeartifact</id>
+      <username>aws</username>
+      <password>${codeartifact.token}</password>
+    </server>
+    <server>
+      <id>sonatype-nexus-staging</id>
+      <username>${sonatype.username}</username>
+      <password>${sonatype.password}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>codeartifact</id>
+      <repositories>
+        <repository>
+          <id>codeartifact</id>
+          <name>codeartifact</name>
+          <url>${codeartifact.url}</url> <!-- passed via command line to avoid hardcoding it here -->
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/codebuild/release/validate-prod.yml
+++ b/codebuild/release/validate-prod.yml
@@ -1,15 +1,18 @@
 version: 0.2
-# 'validate-prod' is an AWS::CodeBuild::Project that validates a Sonatype release
+# 'validate-prod' is an AWS::CodeBuild::Project that validates a Sonatype release against the examples
 
 phases:
   install:
     runtime-versions:
       java: $JAVA_ENV_VERSION
+  pre_build:
+    commands:
+      - cd examples
   build:
     commands:
       - |
         mvn verify \
           -Dcheckstyle.skip \
-          -Desdk.version=$VERSION \
+          -Dddbec.version=$VERSION \
           -Dmaven.compiler.target=$JAVA_NUMERIC_VERSION \
           -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION

--- a/codebuild/release/validate-prod.yml
+++ b/codebuild/release/validate-prod.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# 'validate-prod' is an AWS::CodeBuild::Project that validates a Sonatype release against the examples
+# 'validate-prod' is an AWS::CodeBuild::BuildSpec that validates a Sonatype release against the examples
 
 phases:
   install:

--- a/codebuild/release/validate-prod.yml
+++ b/codebuild/release/validate-prod.yml
@@ -1,0 +1,15 @@
+version: 0.2
+# 'validate-staging' is an AWS::CodeBuild::Project that validates a Sonatype release
+
+phases:
+  install:
+    runtime-versions:
+      java: $JAVA_ENV_VERSION
+  build:
+    commands:
+      - |
+        mvn verify \
+          -Dcheckstyle.skip \
+          -Desdk.version=$VERSION \
+          -Dmaven.compiler.target=$JAVA_NUMERIC_VERSION \
+          -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION

--- a/codebuild/release/validate-prod.yml
+++ b/codebuild/release/validate-prod.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# 'validate-staging' is an AWS::CodeBuild::Project that validates a Sonatype release
+# 'validate-prod' is an AWS::CodeBuild::Project that validates a Sonatype release
 
 phases:
   install:

--- a/codebuild/release/validate-staging.yml
+++ b/codebuild/release/validate-staging.yml
@@ -1,0 +1,32 @@
+version: 0.2
+# 'validate-staging' is an AWS::CodeBuild::Project that validates a CodeArtifact staging before a sonatype release
+
+env:
+  variables:
+    REGION: us-east-1
+    DOMAIN: crypto-tools-internal
+    REPOSITORY: java-ddbec-staging
+  parameter-store:
+    ACCOUNT: /CodeBuild/AccountId
+
+phases:
+    runtime-versions:
+      java: $JAVA_ENV_VERSION
+  pre_build:
+    commands:
+      - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
+      - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
+      - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
+  build:
+    commands:
+      - |
+        mvn verify \
+          -Pcodeartifact \
+          -Dcheckstyle.skip \
+          -Desdk.version=$VERSION \
+          -Dmaven.compiler.target=$JAVA_NUMERIC_VERSION \
+          -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION \
+          -Dcodeartifact.token=$CODEARTIFACT_TOKEN \
+          -Dcodeartifact.url=$CODEARTIFACT_REPO_URL \
+          -s $SETTINGS_FILE
+

--- a/codebuild/release/validate-staging.yml
+++ b/codebuild/release/validate-staging.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# 'validate-staging' is an AWS::CodeBuild::Project that validates a CodeArtifact staging before a sonatype release
+# 'validate-staging' is an AWS::CodeBuild::Project that validates artifacts from CodeArtifact against the examples
 
 env:
   variables:
@@ -17,16 +17,16 @@ phases:
       - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
+      - cd examples
   build:
     commands:
       - |
         mvn verify \
           -Pcodeartifact \
           -Dcheckstyle.skip \
-          -Desdk.version=$VERSION \
+          -Dddbec.version=$VERSION \
           -Dmaven.compiler.target=$JAVA_NUMERIC_VERSION \
           -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION \
           -Dcodeartifact.token=$CODEARTIFACT_TOKEN \
           -Dcodeartifact.url=$CODEARTIFACT_REPO_URL \
           -s $SETTINGS_FILE
-

--- a/codebuild/release/validate-staging.yml
+++ b/codebuild/release/validate-staging.yml
@@ -10,8 +10,8 @@ env:
     ACCOUNT: /CodeBuild/AccountId
 
 phases:
-    runtime-versions:
-      java: $JAVA_ENV_VERSION
+  runtime-versions:
+    java: $JAVA_ENV_VERSION
   pre_build:
     commands:
       - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml

--- a/codebuild/release/validate-staging.yml
+++ b/codebuild/release/validate-staging.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# 'validate-staging' is an AWS::CodeBuild::Project that validates artifacts from CodeArtifact against the examples
+# 'validate-staging' is an AWS::CodeBuild::BuildSpec that validates artifacts from CodeArtifact against the examples
 
 env:
   variables:

--- a/codebuild/release/validate-staging.yml
+++ b/codebuild/release/validate-staging.yml
@@ -10,8 +10,11 @@ env:
     ACCOUNT: /CodeBuild/AccountId
 
 phases:
-  runtime-versions:
-    java: $JAVA_ENV_VERSION
+  install:
+    commands:
+      - pip install awscli
+    runtime-versions:
+      java: $JAVA_ENV_VERSION
   pre_build:
     commands:
       - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,13 +21,16 @@
         <sqlite4java.version>1.0.392</sqlite4java.version>
         <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <ddbec.version>2.0.1</ddbec.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-dynamodb-encryption-java</artifactId>
-            <version>2.0.1</version>
+            <version>${ddbec.version}</version>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -94,10 +94,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Test Release and Prod Release will validate a release on 4 different Java SDKs 

I highly recommend a Squash and Merge approach.

Final commit message should be: `ci: test against multiple JDKs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

