### PR TITLE
chore: Upgrade sdk to 1.12

### DIFF
--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -149,7 +149,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.460</version>
+                <version>1.12.51</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -236,14 +236,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.0</version>
+            <version>2.12.4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.8</version>
+            <version>2.12.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/TransformerHolisticIT.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/TransformerHolisticIT.java
@@ -882,7 +882,7 @@ public class TransformerHolisticIT {
     }
     final File manifestFile = new File(url.getPath());
     final ObjectMapper manifestMapper = new ObjectMapper();
-    return manifestMapper.readValue(manifestFile, typeRef);
+    return (T) manifestMapper.readValue(manifestFile, typeRef);
   }
 
   private static void loadKeyData(String filename) throws IOException {


### PR DESCRIPTION
*Issue #, if available:* Upgrade dependencies. (sdk 1.11 -> 1.12 requires a new version of jackson to be imported, which has a slightly breaking change in the ObjectMapper)

*Description of changes:* `mvn install`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

