### PR TITLE
load library version via local ClassLoader (fixes #147)

### DIFF
--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Utils.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/Utils.java
@@ -57,7 +57,8 @@ public class Utils {
   public static String loadVersion() {
     try {
       final Properties properties = new Properties();
-      properties.load(ClassLoader.getSystemResourceAsStream("project.properties"));
+      final ClassLoader loader = Utils.class.getClassLoader();
+      properties.load(loader.getResourceAsStream("project.properties"));
       return properties.getProperty("version");
     } catch (final IOException ex) {
       return "unknown";


### PR DESCRIPTION
*Issue #, if available:* #147

*Description of changes:* Use local ClassLoader instead of global ClassLoader to load the library's version, fixing incompatibility for SprintBoot-packed application jars.

See also: https://github.com/aws/aws-encryption-sdk-java/pull/269

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

