### PR TITLE
test(examples): add example for DDB Global Table v2017

### DIFF
--- a/codebuild/corretto11.yml
+++ b/codebuild/corretto11.yml
@@ -6,4 +6,4 @@ phases:
             java: corretto11
     build:
         commands:
-          - mvn install
+          - mvn install --no-transfer-progress

--- a/codebuild/corretto8.yml
+++ b/codebuild/corretto8.yml
@@ -6,4 +6,4 @@ phases:
             java: corretto8
     build:
         commands:
-          - mvn install
+          - mvn install --no-transfer-progress

--- a/codebuild/openjdk11.yml
+++ b/codebuild/openjdk11.yml
@@ -6,4 +6,4 @@ phases:
             java: openjdk11
     build:
         commands:
-          - mvn install
+          - mvn install --no-transfer-progress

--- a/codebuild/openjdk8.yml
+++ b/codebuild/openjdk8.yml
@@ -6,4 +6,4 @@ phases:
             java: openjdk8
     build:
         commands:
-          - mvn install
+          - mvn install --no-transfer-progress

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -41,7 +41,8 @@ phases:
           -Dgpg.passphrase="$GPG_PASS" \
           -Dsonatype.username="$SONA_USERNAME" \
           -Dsonatype.password="$SONA_PASSWORD" \
-          -s $SETTINGS_FILE
+          -s $SETTINGS_FILE \
+          --no-transfer-progress
 
 
 batch:

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -47,7 +47,8 @@ phases:
           -Dgpg.passphrase="$GPG_PASS" \
           -Dcodeartifact.token=$CODEARTIFACT_TOKEN \
           -DaltDeploymentRepository=codeartifact::default::$CODEARTIFACT_REPO_URL \
-          -s $SETTINGS_FILE
+          -s $SETTINGS_FILE \
+          --no-transfer-progress
 
 batch:
   fast-fail: false

--- a/codebuild/release/validate-prod.yml
+++ b/codebuild/release/validate-prod.yml
@@ -15,4 +15,5 @@ phases:
           -Dcheckstyle.skip \
           -Dddbec.version=$VERSION \
           -Dmaven.compiler.target=$JAVA_NUMERIC_VERSION \
-          -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION
+          -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION \
+          --no-transfer-progress

--- a/codebuild/release/validate-staging.yml
+++ b/codebuild/release/validate-staging.yml
@@ -32,4 +32,5 @@ phases:
           -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION \
           -Dcodeartifact.token=$CODEARTIFACT_TOKEN \
           -Dcodeartifact.url=$CODEARTIFACT_REPO_URL \
-          -s $SETTINGS_FILE
+          -s $SETTINGS_FILE \
+          --no-transfer-progress

--- a/codebuild/static-analysis.yml
+++ b/codebuild/static-analysis.yml
@@ -6,4 +6,4 @@ phases:
       java: corretto11
   build:
     commands:
-      - mvn com.coveo:fmt-maven-plugin:check
+      - mvn com.coveo:fmt-maven-plugin:check --no-transfer-progress

--- a/examples/src/main/java/com/amazonaws/examples/AwsKmsEncryptedGlobal2017Object.java
+++ b/examples/src/main/java/com/amazonaws/examples/AwsKmsEncryptedGlobal2017Object.java
@@ -36,10 +36,10 @@ public class AwsKmsEncryptedGlobal2017Object {
 
   private static final String AWS_DYNAMODB_REPLICATION_DELETING_ATTRIBUTE = "aws:rep:deleting";
   private static final String AWS_DYNAMODB_REPLICATION_UPDATETIME_ATTRIBUTE = "aws:rep:updatetime";
-  private static final String AWS_DYNAMODB_REPLICATION_UPDATEREGION_ATTRIBUTE = "aws:rep:updateregion";
+  private static final String AWS_DYNAMODB_REPLICATION_UPDATEREGION_ATTRIBUTE =
+      "aws:rep:updateregion";
 
   private static final String STRING_FIELD_NAME = "example";
-
 
   @DynamoDBTable(tableName = EXAMPLE_TABLE_NAME)
   public static final class DataPoJo {
@@ -77,13 +77,13 @@ public class AwsKmsEncryptedGlobal2017Object {
       this.example = example;
     }
 
-
     @DynamoDBAttribute(attributeName = AWS_DYNAMODB_REPLICATION_DELETING_ATTRIBUTE)
     @DynamoDBIgnore
     @DoNotTouch
     public boolean getAws_dynamodb_replication_deleting() {
       return aws_dynamodb_replication_deleting;
     }
+
     public void setAws_dynamodb_replication_deleting(boolean deleting) {
       this.aws_dynamodb_replication_deleting = deleting;
     }
@@ -92,22 +92,22 @@ public class AwsKmsEncryptedGlobal2017Object {
     @DynamoDBIgnore
     @DoNotTouch
     public float getAws_dynamodb_replication_updatetime() {
-        return aws_dynamodb_replication_updatetime;
+      return aws_dynamodb_replication_updatetime;
     }
 
     public void setAws_dynamodb_replication_updatetime(float updatetime) {
-        this.aws_dynamodb_replication_updatetime = updatetime;
+      this.aws_dynamodb_replication_updatetime = updatetime;
     }
 
     @DynamoDBAttribute(attributeName = AWS_DYNAMODB_REPLICATION_UPDATEREGION_ATTRIBUTE)
     @DynamoDBIgnore
     @DoNotTouch
     public String getAws_dynamodb_replication_updateregion() {
-        return aws_dynamodb_replication_updateregion;
+      return aws_dynamodb_replication_updateregion;
     }
 
     public void setAws_dynamodb_replication_updateregion(String updateregion) {
-        this.aws_dynamodb_replication_updateregion = updateregion;
+      this.aws_dynamodb_replication_updateregion = updateregion;
     }
 
     @Override

--- a/examples/src/main/java/com/amazonaws/examples/AwsKmsEncryptedGlobal2017Object.java
+++ b/examples/src/main/java/com/amazonaws/examples/AwsKmsEncryptedGlobal2017Object.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.examples;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.AttributeEncryptor;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DoNotTouch;
+
+/**
+ * This demonstrates how to use the {@link DynamoDBMapper} with the {@link AttributeEncryptor} to
+ * encrypt your data. Before you can use this you need to set up a DynamoDB table called
+ * "ExampleTable" to hold the encrypted data. "ExampleTable" should have a partition key named
+ * "partition_attribute" for Strings and a sort (range) key named "sort_attribute" for numbers.
+ */
+public class AwsKmsEncryptedGlobal2017Object {
+  public static final String EXAMPLE_TABLE_NAME = "ExampleTable";
+  public static final String PARTITION_ATTRIBUTE = "partition_attribute";
+  public static final String SORT_ATTRIBUTE = "sort_attribute";
+
+  private static final String AWS_DYNAMODB_REPLICATION_DELETING_ATTRIBUTE = "aws:rep:deleting";
+  private static final String AWS_DYNAMODB_REPLICATION_UPDATETIME_ATTRIBUTE = "aws:rep:updatetime";
+  private static final String AWS_DYNAMODB_REPLICATION_UPDATEREGION_ATTRIBUTE = "aws:rep:updateregion";
+
+  private static final String STRING_FIELD_NAME = "example";
+
+
+  @DynamoDBTable(tableName = EXAMPLE_TABLE_NAME)
+  public static final class DataPoJo {
+    private String partitionAttribute;
+    private int sortAttribute;
+    private String example;
+    private boolean aws_dynamodb_replication_deleting;
+    private float aws_dynamodb_replication_updatetime;
+    private String aws_dynamodb_replication_updateregion;
+
+    @DynamoDBHashKey(attributeName = PARTITION_ATTRIBUTE)
+    public String getPartitionAttribute() {
+      return partitionAttribute;
+    }
+
+    public void setPartitionAttribute(String partitionAttribute) {
+      this.partitionAttribute = partitionAttribute;
+    }
+
+    @DynamoDBRangeKey(attributeName = SORT_ATTRIBUTE)
+    public int getSortAttribute() {
+      return sortAttribute;
+    }
+
+    public void setSortAttribute(int sortAttribute) {
+      this.sortAttribute = sortAttribute;
+    }
+
+    @DynamoDBAttribute(attributeName = STRING_FIELD_NAME)
+    public String getExample() {
+      return example;
+    }
+
+    public void setExample(String example) {
+      this.example = example;
+    }
+
+
+    @DynamoDBAttribute(attributeName = AWS_DYNAMODB_REPLICATION_DELETING_ATTRIBUTE)
+    @DynamoDBIgnore
+    @DoNotTouch
+    public boolean getAws_dynamodb_replication_deleting() {
+      return aws_dynamodb_replication_deleting;
+    }
+    public void setAws_dynamodb_replication_deleting(boolean deleting) {
+      this.aws_dynamodb_replication_deleting = deleting;
+    }
+
+    @DynamoDBAttribute(attributeName = AWS_DYNAMODB_REPLICATION_UPDATETIME_ATTRIBUTE)
+    @DynamoDBIgnore
+    @DoNotTouch
+    public float getAws_dynamodb_replication_updatetime() {
+        return aws_dynamodb_replication_updatetime;
+    }
+
+    public void setAws_dynamodb_replication_updatetime(float updatetime) {
+        this.aws_dynamodb_replication_updatetime = updatetime;
+    }
+
+    @DynamoDBAttribute(attributeName = AWS_DYNAMODB_REPLICATION_UPDATEREGION_ATTRIBUTE)
+    @DynamoDBIgnore
+    @DoNotTouch
+    public String getAws_dynamodb_replication_updateregion() {
+        return aws_dynamodb_replication_updateregion;
+    }
+
+    public void setAws_dynamodb_replication_updateregion(String updateregion) {
+        this.aws_dynamodb_replication_updateregion = updateregion;
+    }
+
+    @Override
+    public String toString() {
+      return "DataPoJo [partitionAttribute="
+          + partitionAttribute
+          + ", sortAttribute="
+          + sortAttribute
+          + ", example="
+          + example
+          + "]";
+    }
+  }
+}

--- a/examples/src/main/java/com/amazonaws/examples/AwsKmsMultiRegionKey.java
+++ b/examples/src/main/java/com/amazonaws/examples/AwsKmsMultiRegionKey.java
@@ -39,8 +39,8 @@ public class AwsKmsMultiRegionKey {
     AWSKMS kmsEncrypt = null;
     AmazonDynamoDB ddbEncrypt = null;
     AmazonDynamoDB ddbDecrypt = null;
-      //noinspection DuplicatedCode
-      try {
+    //noinspection DuplicatedCode
+    try {
       // Sample object to be encrypted
       AwsKmsEncryptedObject.DataPoJo record = new AwsKmsEncryptedObject.DataPoJo();
       record.setPartitionAttribute("is this");

--- a/examples/src/main/java/com/amazonaws/examples/AwsKmsMultiRegionKeyGlobal2017.java
+++ b/examples/src/main/java/com/amazonaws/examples/AwsKmsMultiRegionKeyGlobal2017.java
@@ -14,6 +14,7 @@ import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
 
 import java.security.GeneralSecurityException;
+import java.util.Random;
 
 /**
  * Example showing use of AWS KMS CMP with an AWS KMS Multi-Region Key. We encrypt a record with a
@@ -41,10 +42,12 @@ public class AwsKmsMultiRegionKeyGlobal2017 {
     AmazonDynamoDB ddbDecrypt = null;
     //noinspection DuplicatedCode
     try {
+      Random random = new Random();
+      int sort_value = random.nextInt();
       // Sample object to be encrypted
       AwsKmsEncryptedGlobal2017Object.DataPoJo record = new AwsKmsEncryptedGlobal2017Object.DataPoJo();
       record.setPartitionAttribute("is this");
-      record.setSortAttribute(42);
+      record.setSortAttribute(sort_value);
       record.setExample("data");
 
       // Set up clients and configuration in the first region. All of this is thread-safe and can be
@@ -76,7 +79,7 @@ public class AwsKmsMultiRegionKeyGlobal2017 {
       // to replicate
       // to the second region
       try {
-        Thread.sleep(1000);
+        Thread.sleep(2000);
       } catch (InterruptedException ignored) {
       }
 
@@ -95,7 +98,7 @@ public class AwsKmsMultiRegionKeyGlobal2017 {
       // call to the
       // first region if your application is running in the second region
       AwsKmsEncryptedGlobal2017Object.DataPoJo decryptedRecord =
-          decryptMapper.load(AwsKmsEncryptedGlobal2017Object.DataPoJo.class, "is this", 42);
+          decryptMapper.load(AwsKmsEncryptedGlobal2017Object.DataPoJo.class, "is this", sort_value);
       System.out.println("Global 2017 Decrypted Record: " + decryptedRecord);
 
       // The decrypted fields match the original fields before encryption
@@ -107,9 +110,11 @@ public class AwsKmsMultiRegionKeyGlobal2017 {
         Thread.sleep(2000);
       } catch (InterruptedException ignored) {
       }
-      AwsKmsEncryptedGlobal2017Object.DataPoJo decryptedRecordTwo = decryptMapper.load(AwsKmsEncryptedGlobal2017Object.DataPoJo.class, "is this", 42);
+      AwsKmsEncryptedGlobal2017Object.DataPoJo decryptedRecordTwo = decryptMapper.load(AwsKmsEncryptedGlobal2017Object.DataPoJo.class, "is this", sort_value);
       System.out.println("Global 2017 Decrypted Record: " + decryptedRecord);
       assert decryptedRecordTwo.getExample().equals(decryptedRecord.getExample());
+
+      encryptMapper.delete(decryptedRecordTwo);
     } finally {
       if (kmsDecrypt != null) {
         kmsDecrypt.shutdown();

--- a/examples/src/main/java/com/amazonaws/examples/AwsKmsMultiRegionKeyGlobal2017.java
+++ b/examples/src/main/java/com/amazonaws/examples/AwsKmsMultiRegionKeyGlobal2017.java
@@ -12,7 +12,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.encryption.DynamoDBEncrypt
 import com.amazonaws.services.dynamodbv2.datamodeling.encryption.providers.DirectKmsMaterialProvider;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
-
 import java.security.GeneralSecurityException;
 import java.util.Random;
 
@@ -45,7 +44,8 @@ public class AwsKmsMultiRegionKeyGlobal2017 {
       Random random = new Random();
       int sort_value = random.nextInt();
       // Sample object to be encrypted
-      AwsKmsEncryptedGlobal2017Object.DataPoJo record = new AwsKmsEncryptedGlobal2017Object.DataPoJo();
+      AwsKmsEncryptedGlobal2017Object.DataPoJo record =
+          new AwsKmsEncryptedGlobal2017Object.DataPoJo();
       record.setPartitionAttribute("is this");
       record.setSortAttribute(sort_value);
       record.setExample("data");
@@ -57,19 +57,19 @@ public class AwsKmsMultiRegionKeyGlobal2017 {
       kmsEncrypt = AWSKMSClientBuilder.standard().withRegion(encryptRegion).build();
       ddbEncrypt = AmazonDynamoDBClientBuilder.standard().withRegion(encryptRegion).build();
       final DirectKmsMaterialProvider cmpEncrypt =
-              new DirectKmsMaterialProvider(kmsEncrypt, cmkArnEncrypt);
+          new DirectKmsMaterialProvider(kmsEncrypt, cmkArnEncrypt);
       final DynamoDBEncryptor encryptor = DynamoDBEncryptor.getInstance(cmpEncrypt);
 
       // Mapper Creation
       // Please note the use of SaveBehavior.PUT (SaveBehavior.CLOBBER works as well).
       // Omitting this can result in data-corruption.
       DynamoDBMapperConfig mapperConfig =
-              DynamoDBMapperConfig.builder()
-                      .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.PUT)
-                      .withTableNameOverride(TableNameOverride.withTableNameReplacement(tableName))
-                      .build();
+          DynamoDBMapperConfig.builder()
+              .withSaveBehavior(DynamoDBMapperConfig.SaveBehavior.PUT)
+              .withTableNameOverride(TableNameOverride.withTableNameReplacement(tableName))
+              .build();
       DynamoDBMapper encryptMapper =
-              new DynamoDBMapper(ddbEncrypt, mapperConfig, new AttributeEncryptor(encryptor));
+          new DynamoDBMapper(ddbEncrypt, mapperConfig, new AttributeEncryptor(encryptor));
 
       System.out.println("Global 2017 Plaintext Record: " + record);
       // Save the item to the DynamoDB table
@@ -79,7 +79,7 @@ public class AwsKmsMultiRegionKeyGlobal2017 {
       // to replicate
       // to the second region
       try {
-        Thread.sleep(2000);
+        Thread.sleep(5000);
       } catch (InterruptedException ignored) {
       }
 
@@ -107,10 +107,11 @@ public class AwsKmsMultiRegionKeyGlobal2017 {
       decryptedRecord.setExample("Howdy");
       encryptMapper.save(decryptedRecord);
       try {
-        Thread.sleep(2000);
+        Thread.sleep(5000);
       } catch (InterruptedException ignored) {
       }
-      AwsKmsEncryptedGlobal2017Object.DataPoJo decryptedRecordTwo = decryptMapper.load(AwsKmsEncryptedGlobal2017Object.DataPoJo.class, "is this", sort_value);
+      AwsKmsEncryptedGlobal2017Object.DataPoJo decryptedRecordTwo =
+          decryptMapper.load(AwsKmsEncryptedGlobal2017Object.DataPoJo.class, "is this", sort_value);
       System.out.println("Global 2017 Decrypted Record: " + decryptedRecord);
       assert decryptedRecordTwo.getExample().equals(decryptedRecord.getExample());
 

--- a/examples/src/test/java/com/amazonaws/examples/AwsKmsMultiRegionKeyGlobal2017IT.java
+++ b/examples/src/test/java/com/amazonaws/examples/AwsKmsMultiRegionKeyGlobal2017IT.java
@@ -3,18 +3,18 @@
 
 package com.amazonaws.examples;
 
-import org.testng.annotations.Test;
-
-import java.security.GeneralSecurityException;
-
 import static com.amazonaws.examples.TestUtils.US_EAST_1_MRK_KEY_ID;
 import static com.amazonaws.examples.TestUtils.US_WEST_2_MRK_KEY_ID;
+
+import java.security.GeneralSecurityException;
+import org.testng.annotations.Test;
 
 public class AwsKmsMultiRegionKeyGlobal2017IT {
   private static final String TABLE_NAME = "tonyknap-manual-mrk-global-2017";
 
   @Test
   public void testEncryptAndDecrypt() throws GeneralSecurityException {
-    AwsKmsMultiRegionKeyGlobal2017.encryptAndDecrypt(TABLE_NAME, US_EAST_1_MRK_KEY_ID, US_WEST_2_MRK_KEY_ID);
+    AwsKmsMultiRegionKeyGlobal2017.encryptAndDecrypt(
+        TABLE_NAME, US_EAST_1_MRK_KEY_ID, US_WEST_2_MRK_KEY_ID);
   }
 }

--- a/examples/src/test/java/com/amazonaws/examples/AwsKmsMultiRegionKeyGlobal2017IT.java
+++ b/examples/src/test/java/com/amazonaws/examples/AwsKmsMultiRegionKeyGlobal2017IT.java
@@ -1,0 +1,20 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.examples;
+
+import org.testng.annotations.Test;
+
+import java.security.GeneralSecurityException;
+
+import static com.amazonaws.examples.TestUtils.US_EAST_1_MRK_KEY_ID;
+import static com.amazonaws.examples.TestUtils.US_WEST_2_MRK_KEY_ID;
+
+public class AwsKmsMultiRegionKeyGlobal2017IT {
+  private static final String TABLE_NAME = "tonyknap-manual-mrk-global-2017";
+
+  @Test
+  public void testEncryptAndDecrypt() throws GeneralSecurityException {
+    AwsKmsMultiRegionKeyGlobal2017.encryptAndDecrypt(TABLE_NAME, US_EAST_1_MRK_KEY_ID, US_WEST_2_MRK_KEY_ID);
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* #68, #69, #70

*Description of changes:* Add an example that demonstrates using an MRK with a DynamoDB Global v2017 table. 

This does not address the features requested in the issues (#68 , #69 , or #70 ) but does demonstrate a work around.
Since those feature requests have been created, DynamoDB has improved Global tables with version 2019.11.21.
As such, I believe that we should close those issues, referencing this Pull Request as the work around for any customers still using Global tables version 2017.11.29.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

