### PR TITLE
Fix some flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
           <plugin>
               <groupId>com.coveo</groupId>
               <artifactId>fmt-maven-plugin</artifactId>
-              <version>2.10</version>
+              <version>2.13</version>
               <!-- Configure no goals. -->
               <!--Until our CI builds no longer depend on Java 8, skip this during build.-->
               <!--We instead manually check this in Java 11 environments to block builds, -->

--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>org.quicktheories</groupId>
             <artifactId>quicktheories</artifactId>
-            <version>0.25</version>
+            <version>0.26</version>
             <scope>test</scope>
         </dependency>
 

--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -123,7 +123,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sqlite4java.version>1.0.392</sqlite4java.version>
-        <checkstyle.version>9.2</checkstyle.version>
+        <checkstyle.version>9.2.1</checkstyle.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>

--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -293,7 +293,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
             </plugin>
 
             <plugin>

--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.12.4</version>
+            <version>2.13.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -149,7 +149,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.129</version>
+                <version>1.12.130</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-ext-jdk15on</artifactId>
-            <version>1.69</version>
+            <version>1.70</version>
             <scope>test</scope>
         </dependency>
 

--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -149,7 +149,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.130</version>
+                <version>1.12.131</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/sdk1/pom.xml
+++ b/sdk1/pom.xml
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Dtest=DynamoDBEncryptorTest#ensureEncryptedAttributesUnmodified``` 
and
```mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=AttributeValueMarshallerTest#testSimpleMapWithNull```
The reason for test flakiness is that Java map API does not preserve the order of the key-value pairs. Comparing maps by casting to string can fail when, for example, the Java version upgrades in the future, or when the code is run in different environment.

**Flaky Tests and Fixes**
- Test:`ensureEncryptedAttributesUnmodified` in `DynamoDBEncryptor.java`.
   Reason & Fix: The test tries to compare two maps after casting them to strings. However, item orders in maps are not preserved.  I converted the referenced maps to TreeMaps before casting them to string.

- Test:`testSimpleMapWithNull` in `AttributeValueMarshallerTest.java`
   Reason & Fix: Part of the expected string is a representation of a map. Similarly, order is not preserved in maps, hence I considered the 2 possible permutation patterns of the string representation of the map.