### PR TITLE
chore: clarify Key.getAlgorithm/Cipher.getInstance usage

### DIFF
--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/WrappedMaterialsProvider.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/providers/WrappedMaterialsProvider.java
@@ -38,6 +38,10 @@ import javax.crypto.SecretKey;
  * <p>This is generally a more secure way of encrypting data than with the {@link
  * SymmetricStaticProvider}.
  *
+ * <p>This class is only as strong as the security of the wrapping/unwrapping keys' underlying
+ * cryptographic algorithm. We recommend using an AES or RSA key, though other algorithms may also
+ * be used.
+ *
  * @see WrappedRawMaterials
  * @author Greg Rubin
  */


### PR DESCRIPTION
*Description of changes:* Adds comments to clarify the intentional usage of Key.getAlgorithm and Cipher.getInstance. This PR does not introduce any functional changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

