### PR TITLE
chore: Copy support policy to 1.x branch

### DIFF
--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -1,0 +1,33 @@
+Overview
+========
+This page describes the support policy for the AWS DynamoDB Encryption Client. We regularly provide the AWS DynamoDB Encryption Client with updates that may contain support for new or updated APIs, new features, enhancements, bug fixes, security patches, or documentation updates. Updates may also address changes with dependencies, language runtimes, and operating systems.
+
+We recommend users to stay up-to-date with DynamoDB Encryption Client releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported SDK version is not recommended and is done at the user’s discretion.
+
+
+Major Version Lifecycle
+========================
+The AWS DynamoDB Encryption Client follows the same major version lifecycle as the AWS SDK. For details on this lifecycle, see  `AWS SDKs and Tools Maintenance Policy`_.
+
+Version Support Matrix
+======================
+This table describes the current support status of each major version of the AWS DynamoDB Encryption Client for Java. It also shows the next status each major version will transition to, and the date at which that transition will happen.
+
+.. list-table::
+    :widths: 30 50 50 50
+    :header-rows: 1
+
+    * - Major version
+      - Current status
+      - Next status
+      - Next status date
+    * - 1.x
+      - Maintenance
+      - End of Support
+      - 2022-07-08
+    * - 2.x
+      - Generally Available
+      -
+      -
+
+.. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The support policy from master was never added to the 1.x branch. This copies it over ahead of the impending 1.x end-of-support release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

