### PR TITLE
fix(docs): Update AWS Doc URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ CachingMostRecentProvider replaces MostRecentProvider and provides a cache entry
 the key with the key provider.
 
 MostRecentProvider is now deprecated, and is removed in 2.0.0.
-See https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/most-recent-provider.html#mrp-versions for more details.
+See https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/most-recent-provider.html#mrp-versions for more details.
 
 1.15.0 also fixes interoperability issues between the Python and Java implementations of DynamoDB Encryption Client.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ automatically.
 Whenever you change your data model, that is, when you add or remove attributes from your table items, you need to take
 additional steps to safely migrate the client-side encryption configuration.
 
-For guidance on this process, please see the developer guide on [Changing Your Data Model](https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/data-model.html).
+For guidance on this process, please see the developer guide on [Changing Your Data Model](https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/data-model.html).
 
 ### Downloads
 

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AttributeEncryptor.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * SaveBehavior#PUT} or {@link SaveBehavior#CLOBBER}.</em>
  *
  * <p>For guidance on performing a safe data model change procedure, please see <a
- * href="https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/data-model.html"
+ * href="https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/data-model.html"
  * target="_blank"> DynamoDB Encryption Client Developer Guide: Changing your data model</a>
  *
  * @author Greg Rubin

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotEncrypt.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotEncrypt.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
  * Prevents the associated item (class or attribute) from being encrypted.
  *
  * <p>For guidance on performing a safe data model change procedure, please see <a
- * href="https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/data-model.html"
+ * href="https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/data-model.html"
  * target="_blank"> DynamoDB Encryption Client Developer Guide: Changing your data model</a>
  *
  * @author Greg Rubin

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotTouch.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DoNotTouch.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
  * Prevents the associated item from being encrypted or signed.
  *
  * <p>For guidance on performing a safe data model change procedure, please see <a
- * href="https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/data-model.html"
+ * href="https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/data-model.html"
  * target="_blank"> DynamoDB Encryption Client Developer Guide: Changing your data model</a>
  *
  * @author Greg Rubin

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptor.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptor.java
@@ -50,7 +50,7 @@ import javax.crypto.spec.IvParameterSpec;
  * attributes.
  *
  * <p>For guidance on performing a safe data model change procedure, please see <a
- * href="https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/data-model.html"
+ * href="https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/data-model.html"
  * target="_blank"> DynamoDB Encryption Client Developer Guide: Changing your data model</a>
  *
  * @author Greg Rubin

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBSigner.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBSigner.java
@@ -42,7 +42,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 /**
  * For guidance on performing a safe data model change procedure, please see <a
- * href="https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/data-model.html"
+ * href="https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/data-model.html"
  * target="_blank"> DynamoDB Encryption Client Developer Guide: Changing your data model</a>
  *
  * @author Greg Rubin

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/HandleUnknownAttributes.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/HandleUnknownAttributes.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * encryption behavior, the unknown attributes will be signed and decrypted.
  *
  * <p>For guidance on performing a safe data model change procedure, please see <a
- * href="https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/data-model.html"
+ * href="https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/data-model.html"
  * target="_blank"> DynamoDB Encryption Client Developer Guide: Changing your data model</a>
  *
  * @author Dan Cavallaro

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/TableAadOverride.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/TableAadOverride.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * to be copied or moved between them without needing to be reencrypted.
  *
  * <p>For guidance on performing a safe data model change procedure, please see <a
- * href="https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/data-model.html"
+ * href="https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/data-model.html"
  * target="_blank"> DynamoDB Encryption Client Developer Guide: Changing your data model</a>
  *
  * @author Greg Rubin


### PR DESCRIPTION
*Issue #, if available:* As part of the new Database Encryption release, the docs for DDBEC-Java have moved. 

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

