### PR TITLE
feat: Update overrideEncryptionContextTableName

### DIFF
--- a/examples/src/main/java/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
+++ b/examples/src/main/java/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapper.java
@@ -46,7 +46,8 @@ import java.util.Set;
  * "partition_attribute" for Strings and a sort (range) key named "sort_attribute" for numbers.
  */
 public class EncryptionContextOverridesWithDynamoDBMapper {
-  public static final String ORIGINAL_TABLE_NAME_TO_OVERRIDE = "ExampleTableForEncryptionContextOverrides";
+  public static final String ORIGINAL_TABLE_NAME_TO_OVERRIDE =
+      "ExampleTableForEncryptionContextOverrides";
   public static final String PARTITION_ATTRIBUTE = "partition_attribute";
   public static final String SORT_ATTRIBUTE = "sort_attribute";
 

--- a/examples/src/test/java/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapperIT.java
+++ b/examples/src/test/java/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapperIT.java
@@ -26,7 +26,7 @@ public class EncryptionContextOverridesWithDynamoDBMapperIT {
     final AmazonDynamoDB ddb = DynamoDBEmbedded.create();
 
     // Create the table under test
-    createDDBTable(ddb, TABLE_NAME_TO_OVERRIDE, PARTITION_ATTRIBUTE, SORT_ATTRIBUTE);
+    createDDBTable(ddb, OVERRIDE_TABLE_NAME, PARTITION_ATTRIBUTE, SORT_ATTRIBUTE);
 
     EncryptionContextOverridesWithDynamoDBMapper.encryptRecord(
         US_WEST_2_KEY_ID, OVERRIDE_TABLE_NAME, ddb, kms);

--- a/examples/src/test/java/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapperIT.java
+++ b/examples/src/test/java/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapperIT.java
@@ -5,7 +5,6 @@ package com.amazonaws.examples;
 
 import static com.amazonaws.examples.EncryptionContextOverridesWithDynamoDBMapper.PARTITION_ATTRIBUTE;
 import static com.amazonaws.examples.EncryptionContextOverridesWithDynamoDBMapper.SORT_ATTRIBUTE;
-import static com.amazonaws.examples.EncryptionContextOverridesWithDynamoDBMapper.TABLE_NAME_TO_OVERRIDE;
 import static com.amazonaws.examples.TestUtils.US_WEST_2;
 import static com.amazonaws.examples.TestUtils.US_WEST_2_KEY_ID;
 import static com.amazonaws.examples.TestUtils.createDDBTable;

--- a/examples/src/test/java/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapperIT.java
+++ b/examples/src/test/java/com/amazonaws/examples/EncryptionContextOverridesWithDynamoDBMapperIT.java
@@ -3,6 +3,7 @@
 
 package com.amazonaws.examples;
 
+import static com.amazonaws.examples.EncryptionContextOverridesWithDynamoDBMapper.ORIGINAL_TABLE_NAME_TO_OVERRIDE;
 import static com.amazonaws.examples.EncryptionContextOverridesWithDynamoDBMapper.PARTITION_ATTRIBUTE;
 import static com.amazonaws.examples.EncryptionContextOverridesWithDynamoDBMapper.SORT_ATTRIBUTE;
 import static com.amazonaws.examples.TestUtils.US_WEST_2;
@@ -25,7 +26,7 @@ public class EncryptionContextOverridesWithDynamoDBMapperIT {
     final AmazonDynamoDB ddb = DynamoDBEmbedded.create();
 
     // Create the table under test
-    createDDBTable(ddb, OVERRIDE_TABLE_NAME, PARTITION_ATTRIBUTE, SORT_ATTRIBUTE);
+    createDDBTable(ddb, ORIGINAL_TABLE_NAME_TO_OVERRIDE, PARTITION_ATTRIBUTE, SORT_ATTRIBUTE);
 
     EncryptionContextOverridesWithDynamoDBMapper.encryptRecord(
         US_WEST_2_KEY_ID, OVERRIDE_TABLE_NAME, ddb, kms);

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
@@ -25,20 +25,18 @@ public class EncryptionContextOperators {
   private EncryptionContextOperators() {}
 
   /**
-   * An operator for overriding EncryptionContext's table name for a specific DynamoDBEncryptor.
-   * If any table names or the encryption context is null, it returns the original EncryptionContext.
+   * An operator for overriding EncryptionContext's table name for a specific DynamoDBEncryptor. If
+   * any table names or the encryption context is null, it returns the original EncryptionContext.
    *
-   * The client automatically adds the current table name to the encryption context
-   * so it's bound to the ciphertext. 
-   * Use this method when the encryption context of encrypted table items includes a different table name,
-   * such as when a table is backed up, or table items are moved/copied to a different table.
-   * If you don't override the name of the current table
-   * with the table name in the encryption context, decrypt fails. 
-   * This override affects the encryption context of all table items,
-   * including newly encrypted items.  
+   * <p>The client automatically adds the current table name to the encryption context so it's bound
+   * to the ciphertext. Use this method when the encryption context of encrypted table items
+   * includes a different table name, such as when a table is backed up, or table items are
+   * moved/copied to a different table. If you don't override the name of the current table with the
+   * table name in the encryption context, decrypt fails. This override affects the encryption
+   * context of all table items, including newly encrypted items.
    *
    * @param originalTableName Use this table name in the encryption context
-   * @param currentTableName Override this table name in the encryption context  
+   * @param currentTableName Override this table name in the encryption context
    * @return A UnaryOperator that produces a new EncryptionContext with the supplied table name
    */
   public static UnaryOperator<EncryptionContext> overrideEncryptionContextTableName(
@@ -51,7 +49,9 @@ public class EncryptionContextOperators {
         return encryptionContext;
       }
       if (originalTableName.equals(encryptionContext.getTableName())) {
-        return new EncryptionContext.Builder(encryptionContext).withTableName(currentTableName).build();
+        return new EncryptionContext.Builder(encryptionContext)
+            .withTableName(currentTableName)
+            .build();
       } else {
         return encryptionContext;
       }

--- a/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
+++ b/sdk1/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/utils/EncryptionContextOperators.java
@@ -25,26 +25,33 @@ public class EncryptionContextOperators {
   private EncryptionContextOperators() {}
 
   /**
-   * An operator for overriding EncryptionContext's table name for a specific DynamoDBEncryptor. If
-   * any table names or the encryption context itself is null, then it returns the original
-   * EncryptionContext.
+   * An operator for overriding EncryptionContext's table name for a specific DynamoDBEncryptor.
+   * If any table names or the encryption context is null, it returns the original EncryptionContext.
    *
-   * @param originalTableName the name of the table that should be overridden in the Encryption
-   *     Context
-   * @param newTableName the table name that should be used in the Encryption Context
+   * The client automatically adds the current table name to the encryption context
+   * so it's bound to the ciphertext. 
+   * Use this method when the encryption context of encrypted table items includes a different table name,
+   * such as when a table is backed up, or table items are moved/copied to a different table.
+   * If you don't override the name of the current table
+   * with the table name in the encryption context, decrypt fails. 
+   * This override affects the encryption context of all table items,
+   * including newly encrypted items.  
+   *
+   * @param originalTableName Use this table name in the encryption context
+   * @param currentTableName Override this table name in the encryption context  
    * @return A UnaryOperator that produces a new EncryptionContext with the supplied table name
    */
   public static UnaryOperator<EncryptionContext> overrideEncryptionContextTableName(
-      String originalTableName, String newTableName) {
+      String originalTableName, String currentTableName) {
     return encryptionContext -> {
       if (encryptionContext == null
           || encryptionContext.getTableName() == null
           || originalTableName == null
-          || newTableName == null) {
+          || currentTableName == null) {
         return encryptionContext;
       }
       if (originalTableName.equals(encryptionContext.getTableName())) {
-        return new EncryptionContext.Builder(encryptionContext).withTableName(newTableName).build();
+        return new EncryptionContext.Builder(encryptionContext).withTableName(currentTableName).build();
       } else {
         return encryptionContext;
       }


### PR DESCRIPTION
The names in `overrideEncryptionContextTableName`
are relative to the code and not the customer using the code.

This updates these names and docs
to reflect the intuition customers have
when dealing with two different table names.

Overriding #754 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

