### PR TITLE
chore: Update SUPPORT_POLICY.rst to move 2.x to maintenance mode

### DIFF
--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -22,12 +22,12 @@ This table describes the current support status of each major version of the AWS
       - Next status
       - Next status date
     * - 1.x
-      - Maintenance
       - End of Support
-      - 2022-07-08
+      - n/a
+      - n/a
     * - 2.x
       - Generally Available
-      -
-      -
+      - Maintenance
+      - 2024-12-16
 
 .. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

now that the [DB-ESDK 3.x](https://github.com/aws/aws-database-encryption-sdk-dynamodb) has been released, 2.x will be moved into maintenance mode in 6 months per the AWS SDKs and Tools Maintenance Policy.

Also move 1.x into End of Support, as the status date has passed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

